### PR TITLE
Permit `validPaths` to use effects

### DIFF
--- a/hnix-store-core/src/System/Nix/Store.hs
+++ b/hnix-store-core/src/System/Nix/Store.hs
@@ -93,7 +93,7 @@ data StoreEffects rootedPath validPath m =
     , -- | Project out the underlying 'rootedPath' from a 'validPath'
       fromValidPath :: !(validPath -> rootedPath)
     , -- | Which of the given paths are valid?
-      validPaths :: !(HashSet rootedPath -> HashSet validPath)
+      validPaths :: !(HashSet rootedPath -> m (HashSet validPath))
     , -- | Get the paths that refer to a given path.
       referrers :: !(validPath -> m (HashSet Path))
     , -- | Get a root to the 'Path'.


### PR DESCRIPTION
According to @shlevy, whether or not a rooted path is a valid path is
not an intrinsic property of the rooted path and requires a side effect
to determine, so this change modifies the `StoreEffects` record to
reflect that.