### PR TITLE
NAR parser/generator

### DIFF
--- a/hnix-store-core/.ghci
+++ b/hnix-store-core/.ghci
@@ -1,0 +1,1 @@
+:set -itests

--- a/hnix-store-core/README.md
+++ b/hnix-store-core/README.md
@@ -7,3 +7,9 @@ See `StoreEffects` in [System.Nix.Store] for the available operations
 on the store.
 
 [System.Nix.Store]: ./src/System/Nix/Store.hs
+
+
+Tests
+======
+
+ - `ghcid --command "cabal repl test-suite:format-tests" --test="Main.main"`

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -19,12 +19,51 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Crypto.Hash.Truncated
                      , System.Nix.Nar
+                     , System.Nix.Path
                      , System.Nix.Store
-  build-depends:       base >=4.10 && <4.11,
-                       -- Drop foundation when we can drop cryptonite <0.25
-                       binary,
-                       bytestring, containers, cryptonite, memory, foundation, basement,
-                       text, regex-base, regex-tdfa-text,
-                       hashable, unordered-containers, bytestring
+  build-depends:       base >=4.10 && <4.11
+                     , basement
+                     , bytestring
+                     , binary
+                     , bytestring
+                     , containers
+                     , cryptonite
+                     , directory
+                     , filepath
+                      -- Drop foundation when we can drop cryptonite <0.25
+                     , foundation
+                     , hashable
+                     , memory
+                     , mtl
+                     , regex-base
+                     , regex-tdfa-text
+                     , text
+                     , unix
+                     , unordered-containers
   hs-source-dirs:      src
   default-language:    Haskell2010
+
+test-suite format-tests
+   ghc-options: -rtsopts -fprof-auto
+   type: exitcode-stdio-1.0
+   main-is: Driver.hs
+   other-modules:
+       NarFormat
+   hs-source-dirs:
+       tests 
+   build-depends:
+       hnix-store-core
+     , base
+     , base64-bytestring
+     , binary
+     , bytestring
+     , containers
+     , directory
+     , process
+     , tasty
+     , tasty-discover
+     , tasty-hspec
+     , tasty-hunit
+     , tasty-quickcheck
+     , text
+   default-language: Haskell2010

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -17,10 +17,13 @@ extra-source-files:  ChangeLog.md, README.md
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     Crypto.Hash.Truncated, System.Nix.Store
+  exposed-modules:     Crypto.Hash.Truncated
+                     , System.Nix.Nar
+                     , System.Nix.Store
   build-depends:       base >=4.10 && <4.11,
                        -- Drop foundation when we can drop cryptonite <0.25
-                       cryptonite, memory, foundation, basement,
+                       binary,
+                       bytestring, containers, cryptonite, memory, foundation, basement,
                        text, regex-base, regex-tdfa-text,
                        hashable, unordered-containers
   hs-source-dirs:      src

--- a/hnix-store-core/src/System/Nix/Nar.hs
+++ b/hnix-store-core/src/System/Nix/Nar.hs
@@ -1,0 +1,181 @@
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-|
+Description : Allowed effects for interacting with Nar files.
+Maintainer  : Shea Levy <shea@shealevy.com>
+|-}
+module System.Nix.Nar where
+
+import           Control.Monad (replicateM, replicateM_)
+import           Data.Monoid ((<>))
+import           Control.Applicative
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import qualified Data.Set as Set
+import qualified Data.Binary as B
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as E
+import qualified Data.Binary.Put as B
+import qualified Data.Binary.Get as B
+import           Debug.Trace
+
+import System.Nix.Path
+
+
+data NarEffects (m :: * -> *) = NarEffets {
+    readFile         :: FilePath -> m BSL.ByteString
+  , listDir          :: FilePath -> m [FileSystemObject]
+  , narFromFileBytes :: BSL.ByteString -> m Nar
+  , narFromDirectory :: FilePath -> m Nar
+}
+
+
+-- Directly taken from Eelco thesis
+-- https://nixos.org/%7Eeelco/pubs/phd-thesis.pdf
+
+-- TODO: Should we use rootedPath, validPath rather than FilePath?
+data Nar = Nar { narFile :: FileSystemObject }
+    deriving (Eq, Ord, Show)
+
+data FileSystemObject =
+    Regular IsExecutable BSL.ByteString
+  | Directory (Set.Set (PathName, FileSystemObject))
+  | SymLink BSL.ByteString
+  deriving (Eq, Show)
+
+-- TODO - is this right? How does thesis define ordering of FSOs?
+instance Ord FileSystemObject where
+    compare (Regular _ c1) (Regular _ c2) = compare c1 c2
+    compare (Regular _ _)  _              = GT
+    compare (Directory s1) (Directory s2) = compare s1 s2
+    compare (Directory _)  _              = GT
+    compare (SymLink l1) (SymLink l2)     = compare l1 l2
+
+data IsExecutable = NonExecutable | Executable
+    deriving (Eq, Show)
+
+-- data NarFile = NarFile
+--     { narFileIsExecutable :: IsExecutable
+--     , narFilePath         :: FilePath -- TODO: Correct type?
+--     } deriving (Show)
+
+data DebugPut = PutAscii | PutBinary
+
+putNar :: Nar -> B.Put
+putNar = putNar' PutBinary
+
+putNar' :: DebugPut -> Nar -> B.Put
+putNar' dbg (Nar file) = header <>
+                         parens (putFile file)
+    where
+
+        str' = case dbg of
+            PutAscii -> strDebug
+            PutBinary -> str
+
+        header   = str' "nix-archive-1"
+        parens m = str' "(" <> m <> str ")"
+
+        putFile (Regular isExec contents) =
+               str' "type" <> str' "regular"
+            <> if isExec == Executable
+               then str' "executable" <> str' ""
+               else str' ""
+            <> str' "contents" <> str' contents
+
+        putFile (SymLink target) =
+               str' "type" <> str' "symlink" <> str' "target" <> str' target
+
+        putFile (Directory entries) =
+               str' "type" <> str' "directory"
+            <> foldMap putEntry entries
+
+        putEntry (PathName name, fso) =
+            str' "entry" <>
+            parens (str' "name" <>
+                    str' (BSL.fromStrict $ E.encodeUtf8 name) <>
+                    str' "node" <>
+                    putFile fso)
+
+getNar :: B.Get Nar
+getNar = fmap Nar $ header >> parens getFile
+    where header   = trace "header " $ assertStr "nix-archive-1"
+
+          padLen n = let r = n `mod` 8
+                         p = (8 - n) `mod` 8
+                     in trace ("padLen: " ++ show p) p
+
+          str = do
+              n <- fmap fromIntegral B.getInt64le
+              s <- B.getLazyByteString n
+              p <- B.getByteString (padLen $ fromIntegral n)
+              traceShow (n,s) $ return s
+
+          assertStr s = trace ("Assert " ++ show s) $ do
+              s' <- str
+              if s == s'
+                  then trace ("Assert " ++ show s ++ " passed") (return s)
+                  else trace ("Assert " ++ show s ++ " failed") (fail "No")
+
+          parens m = assertStr "(" *> m <* assertStr ")"
+
+          getFile :: B.Get FileSystemObject
+          getFile = trace "getFile" (getRegularFile)
+                <|> trace "getDir" (getDirectory)
+                <|> trace "getLink" (getSymLink)
+
+          getRegularFile = trace "regular" $ do
+              trace "TESTING" (assertStr "type")
+              trace "HI" $ assertStr "regular"
+              trace "HI AGOIN" $ assertStr "contents"
+              contents <- str
+              return $ Regular (maybe NonExecutable
+                                   (const Executable) Nothing) contents
+
+          getDirectory = do
+              assertStr "type"
+              assertStr "directory"
+              fs <- many getEntry
+              return $ Directory (Set.fromList fs)
+
+          getSymLink = do
+              assertStr "type"
+              assertStr "symlink"
+              assertStr "target"
+              fmap SymLink str
+
+          getEntry = do
+              assertStr "entry"
+              parens $ do
+                  assertStr "name"
+                  mname <- pathName . E.decodeUtf8 . BSL.toStrict <$> str
+                  assertStr "node"
+                  file <- parens getFile
+                  maybe (fail "Bad PathName") (return . (,file)) mname
+
+str :: BSL.ByteString -> B.Put
+str t = let len = BSL.length t
+    in int len <> pad t
+
+int :: Integral a => a -> B.Put
+int n = B.putInt64le $ fromIntegral n
+
+pad :: BSL.ByteString -> B.Put
+pad bs =
+    let padLen = BSL.length bs `div` 8
+    in  B.put bs >> B.put (BSL.replicate padLen '\NUL')
+
+strDebug :: BSL.ByteString -> B.Put
+strDebug t = let len = BSL.length t
+    in intDebug len <> padDebug t
+
+intDebug :: Integral a => a -> B.Put
+intDebug a = B.put (show @Int (fromIntegral a))
+
+padDebug :: BSL.ByteString -> B.Put
+padDebug bs =
+    let padLen = BSL.length bs `div` 8
+    in  B.put bs >> B.put (BSL.replicate padLen '_')

--- a/hnix-store-core/src/System/Nix/Path.hs
+++ b/hnix-store-core/src/System/Nix/Path.hs
@@ -1,0 +1,76 @@
+{-|
+Description : Types and effects for interacting with the Nix store.
+Maintainer  : Shea Levy <shea@shealevy.com>
+-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module System.Nix.Path
+  ( PathHashAlgo
+  , Path(..)
+  , SubstitutablePathInfo(..)
+  , PathName(..)
+  , pathName
+  ) where
+
+import Crypto.Hash               (Digest)
+import Crypto.Hash.Truncated     (Truncated)
+import Crypto.Hash.Algorithms    (SHA256)
+import qualified Data.ByteArray  as B
+import Data.Text                 (Text)
+import Text.Regex.Base.RegexLike (makeRegex, matchTest)
+import Text.Regex.TDFA.Text      (Regex)
+import Data.Hashable             (Hashable(..), hashPtrWithSalt)
+import Data.HashSet              (HashSet)
+import Data.HashMap.Strict       (HashMap)
+import System.IO.Unsafe          (unsafeDupablePerformIO)
+
+-- | The name portion of a Nix path.
+--
+-- Must be composed of a-z, A-Z, 0-9, +, -, ., _, ?, and =, can't
+-- start with a ., and must have at least one character.
+newtype PathName = PathName
+  { pathNameContents :: Text -- ^ The contents of the path name
+  } deriving (Eq, Ord, Show, Hashable)
+
+-- | A regular expression for matching a valid 'PathName'
+nameRegex :: Regex
+nameRegex =
+  makeRegex "[a-zA-Z0-9\\+\\-\\_\\?\\=][a-zA-Z0-9\\+\\-\\.\\_\\?\\=]*"
+
+-- | Construct a 'PathName', assuming the provided contents are valid.
+pathName :: Text -> Maybe PathName
+pathName n = case matchTest nameRegex n of
+  True -> Just $ PathName n
+  False -> Nothing
+
+-- | The hash algorithm used for store path hashes.
+type PathHashAlgo = Truncated SHA256 20
+
+-- | A path in a store.
+data Path = Path !(Digest PathHashAlgo) !PathName
+
+-- | Wrapper to defined a 'Hashable' instance for 'Digest'.
+newtype HashableDigest a = HashableDigest (Digest a)
+
+instance Hashable (HashableDigest a) where
+  hashWithSalt s (HashableDigest d) = unsafeDupablePerformIO $
+    B.withByteArray d $ \ptr -> hashPtrWithSalt ptr (B.length d) s
+
+instance Hashable Path where
+  hashWithSalt s (Path digest name) =
+    s `hashWithSalt`
+    (HashableDigest digest) `hashWithSalt` name
+
+
+-- | Information about substitutes for a 'Path'.
+data SubstitutablePathInfo = SubstitutablePathInfo
+  { -- | The .drv which led to this 'Path'.
+    deriver :: !(Maybe Path)
+  , -- | The references of the 'Path'
+    references :: !(HashSet Path)
+  , -- | The (likely compressed) size of the download of this 'Path'.
+    downloadSize :: !Integer
+  , -- | The size of the uncompressed NAR serialization of this
+    -- 'Path'.
+    narSize :: !Integer
+  }

--- a/hnix-store-core/src/System/Nix/Store.hs
+++ b/hnix-store-core/src/System/Nix/Store.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PackageImports #-}
+
 {-|
 Description : Types and effects for interacting with the Nix store.
 Maintainer  : Shea Levy <shea@shealevy.com>
@@ -23,55 +25,9 @@ import Data.HashSet (HashSet)
 import Data.HashMap.Strict (HashMap)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
--- | The name portion of a Nix path.
---
--- Must be composed of a-z, A-Z, 0-9, +, -, ., _, ?, and =, can't
--- start with a ., and must have at least one character.
-newtype PathName = PathName
-  { pathNameContents :: Text -- ^ The contents of the path name
-  } deriving (Hashable)
+import System.Nix.Path
+import System.Nix.Nar
 
--- | A regular expression for matching a valid 'PathName'
-nameRegex :: Regex
-nameRegex =
-  makeRegex "[a-zA-Z0-9\\+\\-\\_\\?\\=][a-zA-Z0-9\\+\\-\\.\\_\\?\\=]*"
-
--- | Construct a 'PathName', assuming the provided contents are valid.
-pathName :: Text -> Maybe PathName
-pathName n = case matchTest nameRegex n of
-  True -> Just $ PathName n
-  False -> Nothing
-
--- | The hash algorithm used for store path hashes.
-type PathHashAlgo = Truncated SHA256 20
-
--- | A path in a store.
-data Path = Path !(Digest PathHashAlgo) !PathName
-
--- | Wrapper to defined a 'Hashable' instance for 'Digest'.
-newtype HashableDigest a = HashableDigest (Digest a)
-
-instance Hashable (HashableDigest a) where
-  hashWithSalt s (HashableDigest d) = unsafeDupablePerformIO $
-    B.withByteArray d $ \ptr -> hashPtrWithSalt ptr (B.length d) s
-
-instance Hashable Path where
-  hashWithSalt s (Path digest name) =
-    s `hashWithSalt`
-    (HashableDigest digest) `hashWithSalt` name
-
--- | Information about substitutes for a 'Path'.
-data SubstitutablePathInfo = SubstitutablePathInfo
-  { -- | The .drv which led to this 'Path'.
-    deriver :: !(Maybe Path)
-  , -- | The references of the 'Path'
-    references :: !(HashSet Path)
-  , -- | The (likely compressed) size of the download of this 'Path'.
-    downloadSize :: !Integer
-  , -- | The size of the uncompressed NAR serialization of this
-    -- 'Path'.
-    narSize :: !Integer
-  }
 
 -- | Interactions with the Nix store.
 --
@@ -109,4 +65,5 @@ data StoreEffects rootedPath validPath m =
       derivationOutputNames :: !(validPath -> m (HashSet Text))
     , -- | Get a full 'Path' corresponding to a given 'Digest'.
       pathFromHashPart :: !(Digest PathHashAlgo -> m Path)
+    , narEffects :: NarEffects m
     }

--- a/hnix-store-core/src/System/Nix/Store.hs
+++ b/hnix-store-core/src/System/Nix/Store.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE PackageImports #-}
-
 {-|
 Description : Types and effects for interacting with the Nix store.
 Maintainer  : Shea Levy <shea@shealevy.com>
@@ -66,7 +64,6 @@ data StoreEffects rootedPath validPath m =
       derivationOutputNames :: !(validPath -> m (HashSet Text))
     , -- | Get a full 'Path' corresponding to a given 'Digest'.
       pathFromHashPart :: !(Digest PathHashAlgo -> m Path)
-    , narEffects :: NarEffects m
     , -- | Add a non-nar file to the store
       addFile :: !(BS.ByteString -> m validPath)
     }

--- a/hnix-store-core/tests/Driver.hs
+++ b/hnix-store-core/tests/Driver.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover #-}

--- a/hnix-store-core/tests/NarFormat.hs
+++ b/hnix-store-core/tests/NarFormat.hs
@@ -1,0 +1,356 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module NarFormat where
+
+import           Control.Applicative         ((<|>))
+import           Control.Concurrent          (threadDelay)
+import           Control.Exception           (SomeException, bracket, try)
+import           Control.Monad               (replicateM)
+import           Control.Monad.IO.Class      (liftIO)
+import           Data.Binary                 (put)
+import           Data.Binary.Get             (Get (..), runGet)
+import           Data.Binary.Put             (Put (..), runPut)
+import qualified Data.ByteString             as BS
+import qualified Data.ByteString.Base64.Lazy as B64
+import qualified Data.ByteString.Char8       as BSC
+import qualified Data.ByteString.Lazy        as BSL
+import qualified Data.ByteString.Lazy.Char8  as BSLC
+import           Data.Int
+import qualified Data.Map                    as Map
+import           Data.Maybe                  (fromMaybe, isJust)
+import qualified Data.Text                   as T
+import           GHC.Stats                   (getRTSStats, max_live_bytes)
+import           System.Directory            (removeFile)
+import           System.Environment          (getEnv)
+import qualified System.Process              as P
+import           Test.Tasty                  as T
+import           Test.Tasty.Hspec
+import qualified Test.Tasty.HUnit            as HU
+import           Test.Tasty.QuickCheck
+import           Text.Read                   (readMaybe)
+
+import           System.Nix.Nar
+import           System.Nix.Path
+
+
+
+spec_narEncoding :: Spec
+spec_narEncoding = do
+
+  -- For a Haskell embedded Nar, check that (decode . encode === id)
+  let roundTrip n = runGet getNar (runPut $ putNar n) `shouldBe` n
+
+  -- For a Haskell embedded Nar, check that encoding it gives
+  -- the same bytestring as `nix-store --dump`
+  let encEqualsNixStore n b = runPut (putNar n) `shouldBe` b
+
+
+  describe "parser-roundtrip" $ do
+    it "roundtrips regular" $ do
+      roundTrip (Nar sampleRegular)
+
+    it "roundtrips regular 2" $ do
+      roundTrip (Nar sampleRegular')
+
+    it "roundtrips executable" $ do
+      roundTrip (Nar sampleExecutable)
+
+    it "roundtrips symlink" $ do
+      roundTrip (Nar sampleSymLink)
+
+    it "roundtrips directory" $ do
+      roundTrip (Nar sampleDirectory)
+
+
+  describe "matches-nix-store fixture" $ do
+    it "matches regular" $ do
+      encEqualsNixStore (Nar sampleRegular) sampleRegularBaseline
+
+    it "matches regular'" $
+      encEqualsNixStore (Nar sampleRegular') sampleRegular'Baseline
+
+    it "matches executable" $
+      encEqualsNixStore (Nar sampleExecutable) sampleExecutableBaseline
+
+    it "matches symlink" $
+      encEqualsNixStore (Nar sampleSymLink) sampleSymLinkBaseline
+
+    it "matches directory" $ do
+      encEqualsNixStore (Nar sampleDirectory) sampleDirectoryBaseline
+
+unit_nixStoreRegular :: HU.Assertion
+unit_nixStoreRegular = filesystemNixStore "regular" (Nar sampleRegular)
+
+unit_nixStoreDirectory :: HU.Assertion
+unit_nixStoreDirectory = filesystemNixStore "directory" (Nar sampleDirectory)
+
+unit_nixStoreDirectory' :: HU.Assertion
+unit_nixStoreDirectory' = filesystemNixStore "directory'" (Nar sampleDirectory')
+
+unit_nixStoreBigFile :: HU.Assertion
+unit_nixStoreBigFile = getBigFileSize >>= \sz ->
+  filesystemNixStore "bigfile'" (Nar $ sampleLargeFile sz)
+
+unit_nixStoreBigDir :: HU.Assertion
+unit_nixStoreBigDir = getBigFileSize >>= \sz ->
+  filesystemNixStore "bigfile'" (Nar $ sampleLargeDir sz)
+
+prop_narEncodingArbitrary :: Nar -> Property
+prop_narEncodingArbitrary n = runGet getNar (runPut $ putNar n) === n
+
+unit_packSelfSrcDir :: HU.Assertion
+unit_packSelfSrcDir = do
+  ver <- try (P.readProcess "nix-store" ["--version"] "")
+  case ver of
+    Left  (e :: SomeException) -> print "No nix-store on system"
+    Right _ -> do
+      hnixNar <- runPut . put <$> localPackNar narEffectsIO "src"
+      nixStoreNar <- getNixStoreDump "src"
+      HU.assertEqual
+        "src dir serializes the same between hnix-store and nix-store"
+        hnixNar
+        nixStoreNar
+
+unit_streamLargeFileToNar :: HU.Assertion
+unit_streamLargeFileToNar =
+  bracket (getBigFileSize >>= makeBigFile) (const rmFiles) $ \_ -> do
+    nar <- localPackNar narEffectsIO bigFileName
+    BSL.writeFile narFileName . runPut . put $ nar
+    assertBoundedMemory
+    where
+      bigFileName = "bigFile.bin"
+      narFileName = "bigFile.nar"
+      makeBigFile = \sz -> BSL.writeFile bigFileName
+                           (BSL.take sz $ BSL.cycle "Lorem ipsum")
+      rmFiles     = removeFile bigFileName >> removeFile narFileName
+
+
+-- ****************  Utilities  ************************
+
+-- | Generate the ground-truth encoding on the fly with
+--   `nix-store --dump`, rather than generating fixtures
+--   beforehand
+filesystemNixStore :: String -> Nar -> IO ()
+filesystemNixStore testErrorName n = do
+
+  ver <- try (P.readProcess "nix-store" ["--version"] "")
+  case ver of
+    -- Left is not an error - testing machine simply doesn't have
+    -- `nix-store` executable, so pass
+    Left  (e :: SomeException) -> print "No nix-store on system"
+    Right _ ->
+      bracket (return ()) (\_ -> P.runCommand "rm -rf testfile nixstorenar.nar hnix.nar") $ \_ -> do
+
+      -- stream nar contents to unpacked file(s)
+      localUnpackNar narEffectsIO "testfile" n
+
+      -- nix-store converts those files to nar
+      getNixStoreDump "testfile" >>= BSL.writeFile "nixstorenar.nar"
+
+      -- hnix converts those files to nar
+      localPackNar narEffectsIO "testfile" >>= BSL.writeFile "hnix.nar" . runPut . putNar
+
+      diffResult <- P.readProcess "diff" ["nixstorenar.nar", "hnix.nar"] ""
+
+      assertBoundedMemory
+      HU.assertEqual testErrorName diffResult ""
+
+
+-- | Assert that GHC uses less than 100M memory at peak
+assertBoundedMemory :: IO ()
+assertBoundedMemory = do
+      bytes <- max_live_bytes <$> getRTSStats
+      bytes < 100 * 1000 * 1000 `shouldBe` True
+
+
+-- | Read the binary output of `nix-store --dump` for a filepath
+getNixStoreDump :: String -> IO BSL.ByteString
+getNixStoreDump fp = do
+  (_,Just h, _, _) <- P.createProcess
+                      (P.proc "nix-store" ["--dump", fp])
+                      {P.std_out = P.CreatePipe}
+  BSL.hGetContents h
+
+
+-- * Several sample FSOs defined in Haskell, for use in encoding/decoding
+
+-- | Simple regular text file with contents 'hi'
+sampleRegular :: FileSystemObject
+sampleRegular = Regular NonExecutable 3 "hi\n"
+
+-- | Simple text file with some c code
+sampleRegular' :: FileSystemObject
+sampleRegular' = Regular NonExecutable (BSL.length str) str
+  where str =
+          "#include <stdio.h>\n\nint main(int argc, char *argv[]){ exit 0; }\n"
+
+-- | Executable file
+sampleExecutable :: FileSystemObject
+sampleExecutable = Regular Executable (BSL.length str) str
+  where str = "#!/bin/bash\n\ngcc -o hello hello.c\n"
+
+-- | A simple symlink
+sampleSymLink :: FileSystemObject
+sampleSymLink = SymLink "hello.c"
+
+
+-- | A directory that includes some of the above sample files
+sampleDirectory :: FileSystemObject
+sampleDirectory = Directory $ Map.fromList
+  [(FilePathPart "hello.c", sampleRegular')
+  ,(FilePathPart "build.sh", sampleExecutable)
+  ,(FilePathPart "hi.c", sampleSymLink)
+  ]
+
+-- | A deeper directory tree with crossing links
+sampleDirectory' :: FileSystemObject
+sampleDirectory' = Directory $ Map.fromList [
+
+    (FilePathPart "foo", Directory $ Map.fromList [
+        (FilePathPart "foo.txt", Regular NonExecutable 8 "foo text")
+      , (FilePathPart "tobar"  , SymLink "../bar/bar.txt")
+      ])
+
+  , (FilePathPart "bar", Directory $ Map.fromList [
+        (FilePathPart "bar.txt", Regular NonExecutable 8 "bar text")
+      , (FilePathPart "tofoo"  , SymLink "../foo/foo.txt")
+      ])
+  ]
+
+sampleLargeFile :: Int64 -> FileSystemObject
+sampleLargeFile fSize =
+  Regular NonExecutable fSize (BSL.take fSize (BSL.cycle "Lorem ipsum "))
+
+
+sampleLargeFile' :: Int64 -> FileSystemObject
+sampleLargeFile' fSize =
+  Regular NonExecutable fSize (BSL.take fSize (BSL.cycle "Lorems ipsums "))
+
+sampleLargeDir :: Int64 -> FileSystemObject
+sampleLargeDir fSize = Directory $ Map.fromList $ [
+    (FilePathPart "bf1", sampleLargeFile  fSize)
+  , (FilePathPart "bf2", sampleLargeFile' fSize)
+  ]
+  ++ [ (FilePathPart (BSC.pack $ 'f' : show n),
+        Regular NonExecutable 10000 (BSL.take 10000 (BSL.cycle "hi ")))
+     | n <- [1..100]]
+  ++ [
+  (FilePathPart "d", Directory $ Map.fromList
+      [ (FilePathPart (BSC.pack $ "df" ++ show n)
+        , Regular NonExecutable 10000 (BSL.take 10000 (BSL.cycle "subhi ")))
+      | n <- [1..100]]
+     )
+  ]
+
+-- * For each sample above, feed it into `nix-store --dump`,
+-- and base64 encode the resulting NAR binary. This lets us
+-- check our Haskell NAR generator against `nix-store`
+
+-- "hi" file turned to a NAR with `nix-store --dump`, Base64 encoded
+sampleRegularBaseline :: BSL.ByteString
+sampleRegularBaseline = B64.decodeLenient
+  "DQAAAAAAAABuaXgtYXJjaGl2ZS0xAAAAAQAAAAAAAAAoAAAAAAA\
+  \AAAQAAAAAAAAAdHlwZQAAAAAHAAAAAAAAAHJlZ3VsYXIACAAAAA\
+  \AAAABjb250ZW50cwMAAAAAAAAAaGkKAAAAAAABAAAAAAAAACkAA\
+  \AAAAAAA"
+
+sampleRegular'Baseline :: BSL.ByteString
+sampleRegular'Baseline = B64.decodeLenient
+  "DQAAAAAAAABuaXgtYXJjaGl2ZS0xAAAAAQAAAAAAAAAoAAAAAAA\
+  \AAAQAAAAAAAAAdHlwZQAAAAAHAAAAAAAAAHJlZ3VsYXIACAAAAA\
+  \AAAABjb250ZW50c0AAAAAAAAAAI2luY2x1ZGUgPHN0ZGlvLmg+C\
+  \gppbnQgbWFpbihpbnQgYXJnYywgY2hhciAqYXJndltdKXsgZXhp\
+  \dCAwOyB9CgEAAAAAAAAAKQAAAAAAAAA="
+
+sampleExecutableBaseline :: BSL.ByteString
+sampleExecutableBaseline = B64.decodeLenient
+  "DQAAAAAAAABuaXgtYXJjaGl2ZS0xAAAAAQAAAAAAAAAoAAAAAAA\
+  \AAAQAAAAAAAAAdHlwZQAAAAAHAAAAAAAAAHJlZ3VsYXIACgAAAA\
+  \AAAABleGVjdXRhYmxlAAAAAAAAAAAAAAAAAAAIAAAAAAAAAGNvb\
+  \nRlbnRzIgAAAAAAAAAjIS9iaW4vYmFzaAoKZ2NjIC1vIGhlbGxv\
+  \IGhlbGxvLmMKAAAAAAAAAQAAAAAAAAApAAAAAAAAAA=="
+
+sampleSymLinkBaseline :: BSL.ByteString
+sampleSymLinkBaseline = B64.decodeLenient
+  "DQAAAAAAAABuaXgtYXJjaGl2ZS0xAAAAAQAAAAAAAAAoAAAAAAA\
+  \AAAQAAAAAAAAAdHlwZQAAAAAHAAAAAAAAAHN5bWxpbmsABgAAAA\
+  \AAAAB0YXJnZXQAAAcAAAAAAAAAaGVsbG8uYwABAAAAAAAAACkAA\
+  \AAAAAAA"
+
+sampleDirectoryBaseline :: BSL.ByteString
+sampleDirectoryBaseline = B64.decodeLenient
+  "DQAAAAAAAABuaXgtYXJjaGl2ZS0xAAAAAQAAAAAAAAAoAAAAAAA\
+  \AAAQAAAAAAAAAdHlwZQAAAAAJAAAAAAAAAGRpcmVjdG9yeQAAAA\
+  \AAAAAFAAAAAAAAAGVudHJ5AAAAAQAAAAAAAAAoAAAAAAAAAAQAA\
+  \AAAAAAAbmFtZQAAAAAIAAAAAAAAAGJ1aWxkLnNoBAAAAAAAAABu\
+  \b2RlAAAAAAEAAAAAAAAAKAAAAAAAAAAEAAAAAAAAAHR5cGUAAAA\
+  \ABwAAAAAAAAByZWd1bGFyAAoAAAAAAAAAZXhlY3V0YWJsZQAAAA\
+  \AAAAAAAAAAAAAACAAAAAAAAABjb250ZW50cyIAAAAAAAAAIyEvY\
+  \mluL2Jhc2gKCmdjYyAtbyBoZWxsbyBoZWxsby5jCgAAAAAAAAEA\
+  \AAAAAAAAKQAAAAAAAAABAAAAAAAAACkAAAAAAAAABQAAAAAAAAB\
+  \lbnRyeQAAAAEAAAAAAAAAKAAAAAAAAAAEAAAAAAAAAG5hbWUAAA\
+  \AABwAAAAAAAABoZWxsby5jAAQAAAAAAAAAbm9kZQAAAAABAAAAA\
+  \AAAACgAAAAAAAAABAAAAAAAAAB0eXBlAAAAAAcAAAAAAAAAcmVn\
+  \dWxhcgAIAAAAAAAAAGNvbnRlbnRzQAAAAAAAAAAjaW5jbHVkZSA\
+  \8c3RkaW8uaD4KCmludCBtYWluKGludCBhcmdjLCBjaGFyICphcm\
+  \d2W10peyBleGl0IDA7IH0KAQAAAAAAAAApAAAAAAAAAAEAAAAAA\
+  \AAAKQAAAAAAAAAFAAAAAAAAAGVudHJ5AAAAAQAAAAAAAAAoAAAA\
+  \AAAAAAQAAAAAAAAAbmFtZQAAAAAEAAAAAAAAAGhpLmMAAAAABAA\
+  \AAAAAAABub2RlAAAAAAEAAAAAAAAAKAAAAAAAAAAEAAAAAAAAAH\
+  \R5cGUAAAAABwAAAAAAAABzeW1saW5rAAYAAAAAAAAAdGFyZ2V0A\
+  \AAHAAAAAAAAAGhlbGxvLmMAAQAAAAAAAAApAAAAAAAAAAEAAAAA\
+  \AAAAKQAAAAAAAAABAAAAAAAAACkAAAAAAAAA"
+
+
+-- | Control testcase sizes (bytes) by env variable
+getBigFileSize :: IO Int64
+getBigFileSize = fromMaybe 1000000 . readMaybe <$> (getEnv "HNIX_BIG_FILE_SIZE" <|> pure "")
+
+
+-- | Add a link to a FileSystemObject. This is useful
+--   when creating Arbitrary FileSystemObjects. It
+--   isn't implemented yet
+mkLink ::
+     FilePath -- ^ Target
+  -> FilePath -- ^ Link
+  -> FileSystemObject -- ^ FileSystemObject to add link to
+  -> FileSystemObject
+mkLink = undefined -- TODO
+
+
+instance Arbitrary Nar where
+  arbitrary = Nar <$> resize 10 arbitrary
+
+instance Arbitrary FileSystemObject where
+  -- To build an arbitrary Nar,
+  arbitrary = do
+    n <- getSize
+    if n < 2
+      then arbFile
+      else arbDirectory n
+
+      where
+
+        arbFile :: Gen FileSystemObject
+        arbFile = do
+          Positive fSize <- arbitrary
+          Regular
+            <$> elements [NonExecutable, Executable]
+            <*> pure (fromIntegral fSize)
+            <*> oneof  [
+                  fmap (BSL.take fSize . BSL.cycle . BSL.pack . getNonEmpty) arbitrary , -- Binary File
+                  fmap (BSL.take fSize . BSL.cycle . BSLC.pack . getNonEmpty) arbitrary   -- ASCII  File
+                  ]
+
+        arbName :: Gen FilePathPart
+        arbName = fmap (FilePathPart . BS.pack . fmap (fromIntegral . fromEnum)) $ do
+          Positive n <- arbitrary
+          replicateM n (elements $ ['a'..'z'] ++ ['0'..'9'])
+
+        arbDirectory :: Int -> Gen FileSystemObject
+        arbDirectory n = fmap (Directory . Map.fromList) $ replicateM n $ do
+          nm <- arbName
+          f <- oneof [arbFile, arbDirectory (n `div` 2)]
+          return (nm,f)


### PR DESCRIPTION
NAR parser and generator. Moved `Path` types and functions into `Paths.hs` module.

### Todo
 - [x] cleanup
 - [x] test the generator manually
 - [x] create tests (parse . gen === id)
 - [x] finish the `binary` instance
 - [x] test encoding/decoding for large NARs (tried 10 and 12 Mb - found problems at 12)
   - can we stream in constant space? (moved to its own ticket)
   - what do we do with NARs beyond using them as intermediate form between download and unpack for computing store path hash? Provide API for doing these things (moved to its own ticket)
 - [x] factor IO out of `localUnpackNar` - use `NarEffects` monad instead
 - [x] Write an IO instance for `NarEffects`

### Testing Done

Our encoder and decoder, filesystem packer and filesystem unpacker are all checked against each other and against the output of `nix-store --dump`.

Some of our tests use generated files about 8MB in size, and a realistic directory (the `src` directory of this project) for head-to-head comparisons with `nix-store --dump`.

```
*NarFormat Main> main
tests/Driver.hs
  narEncoding
    parser-roundtrip
      roundtrips regular:    OK
      roundtrips regular 2:  OK
      roundtrips executable: OK
      roundtrips symlink:    OK
      roundtrips directory:  OK
    matches-nix-store fixture
      matches regular:       OK
      matches regular':      OK
      matches executable:    OK
      matches symlink:       OK
      matches directory:     OK
  nixStoreRegular:           OK (0.03s)
  nixStoreDirectory:         OK (0.03s)
  nixStoreDirectory':        OK (0.03s)
  nixStoreBigFile:           OK (0.15s)
  nixStoreBigDir:            OK (0.34s)
  narEncodingArbitrary:      OK (0.18s)
    +++ OK, passed 100 tests.
  packSelfSrcDir:            OK (0.03s)

All 17 tests passed (0.80s)
```
