### PR TITLE
Weird bit fiddling to make `printHashBytes32` work

### DIFF
--- a/hnix-store-core/src/System/Nix/Internal/Hash.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Hash.hs
@@ -125,7 +125,10 @@ newtype Digest (a :: HashAlgorithm) = Digest
 printHashBytes32 :: BS.ByteString -> T.Text
 printHashBytes32 c = T.pack $ concatMap char32 [nChar - 1, nChar - 2 .. 0]
   where
-    -- The base32 encoding is 8/5's as long as the base256 digest
+    -- The base32 encoding is 8/5's as long as the base256 digest.  This `+ 1`
+    -- `- 1` business is a bit odd, but has always been used in C++ since the
+    -- base32 truncation was added in was first added in
+    -- d58a11e019813902b6c4547ca61a127938b2cc20.
     nChar = fromIntegral $ ((BS.length c * 8 - 1) `div` 5) + 1
 
     char32 :: Integer -> [Char]

--- a/hnix-store-core/src/System/Nix/Internal/Hash.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Hash.hs
@@ -126,7 +126,7 @@ printHashBytes32 :: BS.ByteString -> T.Text
 printHashBytes32 c = T.pack $ concatMap char32 [nChar - 1, nChar - 2 .. 0]
   where
     -- The base32 encoding is 8/5's as long as the base256 digest
-    nChar = fromIntegral $ BS.length c * 8 `div` 5
+    nChar = fromIntegral $ ((BS.length c * 8 - 1) `div` 5) + 1
 
     char32 :: Integer -> [Char]
     char32 i = [digits32 V.! digitInd]

--- a/hnix-store-core/tests/Hash.hs
+++ b/hnix-store-core/tests/Hash.hs
@@ -31,6 +31,10 @@ spec_hash = do
 
   describe "hashing parity with nix-store" $ do
 
+    it "produces (base32 . sha256) of \"nix-output:foo\" the same as Nix does at the moment for placeholder \"foo\"" $
+      shouldBe (printAsBase32 (hash @SHA256 "nix-output:foo"))
+               "1x0ymrsy7yr7i9wdsqy9khmzc1yy7nvxw6rdp72yzn50285s67j5"
+
     it "produces (base32 . sha1) of \"Hello World\" the same as the thesis" $
       shouldBe (printAsBase32 (hash @SHA1 "Hello World"))
                "s23c9fs0v32pf6bhmcph5rbqsyl5ak8a"


### PR DESCRIPTION
> builtins.placeholder "asdf"

should be

> "/1x0ymrsy7yr7i9wdsqy9khmzc1yy7nvxw6rdp72yzn50285s67j5"

but was 

> "/x0ymrsy7yr7i9wdsqy9khmzc1yy7nvxw6rdp72yzn50285s67j5"

i.e. no leading 1