### PR TITLE
regex-tdfa 1.3.1.0 replaces regex-tdfa-text.

### DIFF
--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -42,7 +42,7 @@ library
                      , hashable
                      , mtl
                      , regex-base
-                     , regex-tdfa-text
+                     , regex-tdfa >= 1.3.1.0
                      , saltine
                      , time
                      , text


### PR DESCRIPTION
See https://github.com/haskell-hvr/regex-tdfa/issues/4