### PR TITLE
Base16/Base32 decoding, props/tests 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@
 in {
   haskellPackages =
     pkgs.haskellPackages.override overrideHaskellPackages;
-  haskell844Packages =
-    pkgs.haskell.packages.ghc844.override overrideHaskellPackages;
+  haskell865Packages =
+    pkgs.haskell.packages.ghc865.override overrideHaskellPackages;
   inherit pkgs;
 }

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -19,6 +19,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     System.Nix.Base32
                      , System.Nix.Hash
+                     , System.Nix.Internal.Base32
                      , System.Nix.Internal.Hash
                      , System.Nix.Internal.Signature
                      , System.Nix.Internal.StorePath
@@ -63,6 +64,7 @@ test-suite format-tests
    type: exitcode-stdio-1.0
    main-is: Driver.hs
    other-modules:
+       Arbitrary
        NarFormat
        Hash
    hs-source-dirs:
@@ -70,6 +72,7 @@ test-suite format-tests
    build-depends:
        hnix-store-core
      , base
+     , base16-bytestring
      , base64-bytestring
      , binary
      , bytestring

--- a/hnix-store-core/src/System/Nix/Base32.hs
+++ b/hnix-store-core/src/System/Nix/Base32.hs
@@ -1,39 +1,9 @@
 {-|
 Description: Implementation of Nix's base32 encoding.
 -}
-module System.Nix.Base32 where
+module System.Nix.Base32 (
+    encode
+  , decode
+  ) where
 
-import qualified Data.ByteString        as BS
-import qualified Data.Text              as T
-import qualified Data.Vector            as V
-
--- | Encode a 'BS.ByteString' in Nix's base32 encoding
-encode :: BS.ByteString -> T.Text
-encode c = T.pack $ map char32 [nChar - 1, nChar - 2 .. 0]
-  where
-    digits32 = V.fromList "0123456789abcdfghijklmnpqrsvwxyz"
-    -- Each base32 character gives us 5 bits of information, while
-    -- each byte gives is 8. Because 'div' rounds down, we need to add
-    -- one extra character to the result, and because of that extra 1
-    -- we need to subtract one from the number of bits in the
-    -- bytestring to cover for the case where the number of bits is
-    -- already a factor of 5. Thus, the + 1 outside of the 'div' and
-    -- the - 1 inside of it.
-    nChar = fromIntegral $ ((BS.length c * 8 - 1) `div` 5) + 1
-
-    byte = BS.index c . fromIntegral
-
-    -- May need to switch to a more efficient calculation at some
-    -- point.
-    bAsInteger :: Integer
-    bAsInteger = sum [fromIntegral (byte j) * (256 ^ j)
-                     | j <- [0 .. BS.length c - 1]
-                     ]
-
-    char32 :: Integer -> Char
-    char32 i = digits32 V.! digitInd
-      where
-        digitInd = fromIntegral $
-                   bAsInteger
-                   `div` (32^i)
-                   `mod` 32
+import System.Nix.Internal.Base32

--- a/hnix-store-core/src/System/Nix/Hash.hs
+++ b/hnix-store-core/src/System/Nix/Hash.hs
@@ -12,7 +12,9 @@ module System.Nix.Hash (
   , HNix.hashLazy
 
   , HNix.encodeBase32
+  , HNix.decodeBase32
   , HNix.encodeBase16
+  , HNix.decodeBase16
   ) where
 
 import qualified System.Nix.Internal.Hash as HNix

--- a/hnix-store-core/src/System/Nix/Internal/Base32.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Base32.hs
@@ -1,0 +1,82 @@
+
+module System.Nix.Internal.Base32 where
+
+import Data.Bits (shiftR)
+import Data.Char (chr, ord)
+import Data.Word (Word8)
+import Data.List (unfoldr)
+import Data.Maybe (isJust, catMaybes)
+import qualified Data.ByteString        as BS
+import qualified Data.ByteString.Char8  as BSC
+import qualified Data.Text              as T
+import qualified Data.Vector            as V
+import Numeric (readInt)
+
+-- omitted: E O U T
+digits32 = V.fromList "0123456789abcdfghijklmnpqrsvwxyz"
+
+-- | Encode a 'BS.ByteString' in Nix's base32 encoding
+encode :: BS.ByteString -> T.Text
+encode c = T.pack $ map char32 [nChar - 1, nChar - 2 .. 0]
+  where
+    -- Each base32 character gives us 5 bits of information, while
+    -- each byte gives is 8. Because 'div' rounds down, we need to add
+    -- one extra character to the result, and because of that extra 1
+    -- we need to subtract one from the number of bits in the
+    -- bytestring to cover for the case where the number of bits is
+    -- already a factor of 5. Thus, the + 1 outside of the 'div' and
+    -- the - 1 inside of it.
+    nChar = fromIntegral $ ((BS.length c * 8 - 1) `div` 5) + 1
+
+    byte = BS.index c . fromIntegral
+
+    -- May need to switch to a more efficient calculation at some
+    -- point.
+    bAsInteger :: Integer
+    bAsInteger = sum [fromIntegral (byte j) * (256 ^ j)
+                     | j <- [0 .. BS.length c - 1]
+                     ]
+
+    char32 :: Integer -> Char
+    char32 i = digits32 V.! digitInd
+      where
+        digitInd = fromIntegral $
+                   bAsInteger
+                   `div` (32^i)
+                   `mod` 32
+
+-- | Decode Nix's base32 encoded text
+decode :: T.Text -> Either String BS.ByteString
+decode what = case T.all (flip elem digits32) what of
+  True  -> unsafeDecode what
+  False -> Left "Invalid base32 string"
+
+-- | Decode Nix's base32 encoded text
+-- Doesn't check if all elements match `digits32`
+unsafeDecode :: T.Text -> Either String BS.ByteString
+unsafeDecode what =
+  case readInt 32
+         (flip elem digits32)
+         (\c -> maybe (error "character not in digits32") id $
+                  V.findIndex (==c) digits32)
+         (T.unpack what)
+    of
+      [(i, _)] -> Right $ padded $ integerToBS i
+      x        -> Left $ "Can't decode: readInt returned " ++ show x
+  where
+    padded x | BS.length x < decLen = x `BS.append`
+      (BSC.pack $ take (decLen - BS.length x) (cycle "\NUL"))
+    padded x | otherwise = x
+
+    decLen = T.length what * 5 `div` 8
+
+-- | Encode an Integer to a bytestring
+-- Similar to Data.Base32String (integerToBS) without `reverse`
+integerToBS :: Integer -> BS.ByteString
+integerToBS 0 = BS.pack [0]
+integerToBS i
+    | i > 0     = BS.pack $ unfoldr f i
+    | otherwise = error "integerToBS not defined for negative values"
+  where
+    f 0 = Nothing
+    f x = Just (fromInteger x :: Word8, x `shiftR` 8)

--- a/hnix-store-core/src/System/Nix/Internal/Hash.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Hash.hs
@@ -99,9 +99,19 @@ hashLazy bsl =
 encodeBase32 :: Digest a -> T.Text
 encodeBase32 (Digest bs) = Base32.encode bs
 
+-- | Decode a 'Digest' in the special Nix base-32 encoding.
+decodeBase32 :: T.Text -> Either String (Digest a)
+decodeBase32 t = Digest <$> Base32.decode t
+
 -- | Encode a 'Digest' in hex.
 encodeBase16 :: Digest a -> T.Text
 encodeBase16 (Digest bs) = T.decodeUtf8 (Base16.encode bs)
+
+-- | Decode a 'Digest' in hex
+decodeBase16 :: T.Text -> Either String (Digest a)
+decodeBase16 t = case Base16.decode (T.encodeUtf8 t) of
+  (x, "") -> Right $ Digest x
+  _       -> Left $ "Unable to decode base16 string " ++ T.unpack t
 
 -- | Uses "Crypto.Hash.MD5" from cryptohash-md5.
 instance ValidAlgo 'MD5 where

--- a/hnix-store-core/tests/Arbitrary.hs
+++ b/hnix-store-core/tests/Arbitrary.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE DataKinds            #-}
+
+module Arbitrary where
+
+import           Control.Monad               (replicateM)
+import qualified Data.ByteString.Char8       as BSC
+import qualified Data.Text                   as T
+
+import           Test.Tasty.QuickCheck
+
+import           System.Nix.Hash
+import           System.Nix.Internal.Hash
+import           System.Nix.StorePath
+import           System.Nix.Internal.StorePath
+
+genSafeChar :: Gen Char
+genSafeChar = choose ('\1', '\127') -- ASCII without \NUL
+
+nonEmptyString :: Gen String
+nonEmptyString = listOf1 genSafeChar
+
+dir = ('/':) <$> (listOf1 $ elements $ ('/':['a'..'z']))
+
+instance Arbitrary StorePathName where
+  arbitrary = StorePathName . T.pack
+    <$> ((:) <$> s1 <*> listOf sn)
+    where
+      alphanum = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9']
+      s1 = elements $ alphanum ++ "+-_?="
+      sn = elements $ alphanum ++ "+-._?="
+
+instance Arbitrary (Digest StorePathHashAlgo) where
+  arbitrary = hash . BSC.pack <$> arbitrary
+
+instance Arbitrary (Digest SHA256) where
+  arbitrary = hash . BSC.pack <$> arbitrary


### PR DESCRIPTION
Moves Nix-en/decoding code to Internal.Base32, adds more tests and arbitrary instances.