### PR TITLE
hnix-store-remote: Remove ExceptT, use DList to accumulate log.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 dist-newstyle
 .ghc.environment*
+cabal.project.local

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -26,6 +26,7 @@ library
                      , binary
                      , bytestring
                      , containers
+                     , dlist
                      , text
                      , unix
                      , network

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Util.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Util.hs
@@ -2,7 +2,6 @@ module System.Nix.Store.Remote.Util where
 
 import           Control.Monad.Reader
 
-import           Data.Maybe
 import           Data.Binary.Get
 import           Data.Binary.Put
 import           Data.Text                 (Text)
@@ -10,12 +9,10 @@ import qualified Data.Text                 as T
 import qualified Data.ByteString           as B
 import qualified Data.ByteString.Char8     as BSC
 import qualified Data.ByteString.Lazy      as LBS
-import qualified Data.HashSet              as HashSet
 
 import           Network.Socket.ByteString (recv, sendAll)
 
 import           System.Nix.Store.Remote.Types
-import           System.Nix.Hash
 import           System.Nix.Util
 
 


### PR DESCRIPTION
This PR refactors two bits in the worker protocol implementation:

- A superfluous ExceptT layer is removed. IO is at the base of the stack anyway, so nothing is gained from adding and additional, out-of-band error handling mechanism; callers that care about IO failure will have a set of exception handlers anyway.
- DList is used to accumulate the log. It seems that for long-running interactions with the store there should be a way to stream these log chunks, but this is a partial improvement that isn't opinionated about how the streaming is done.