### PR TITLE
Fix text encoding to utf8

### DIFF
--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -62,6 +62,8 @@ test-suite hnix-store-remote-tests
    main-is:           Driver.hs
    other-modules:     Derivation
                     , NixDaemon
+                    , Spec
+                    , Util
    hs-source-dirs:    tests
    build-depends:
                        attoparsec
@@ -76,6 +78,7 @@ test-suite hnix-store-remote-tests
                      , process
                      , filepath
                      , hspec-expectations-lifted
+                     , quickcheck-text
                      , tasty
                      , tasty-discover
                      , tasty-hspec

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Util.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Util.hs
@@ -11,6 +11,9 @@ import           Data.Binary.Get
 import           Data.Binary.Put
 import           Data.Text                 (Text)
 import qualified Data.Text                 as T
+import qualified Data.Text.Encoding        as T
+import qualified Data.Text.Lazy            as TL
+import qualified Data.Text.Lazy.Encoding   as TL
 import           Data.Time
 import           Data.Time.Clock.POSIX
 import           Data.ByteString           (ByteString)
@@ -91,13 +94,16 @@ sockGetPaths = do
   getSocketIncremental (getPaths sd)
 
 bsToText :: ByteString -> Text
-bsToText = T.pack . BSC.unpack
+bsToText = T.decodeUtf8
+
+textToBS :: Text -> ByteString
+textToBS = T.encodeUtf8
 
 bslToText :: BSL.ByteString -> Text
-bslToText = T.pack . BSC.unpack . BSL.toStrict
+bslToText = TL.toStrict . TL.decodeUtf8
 
 textToBSL :: Text -> BSL.ByteString
-textToBSL = BSL.fromStrict . BSC.pack . T.unpack
+textToBSL = TL.encodeUtf8 . TL.fromStrict
 
 putText :: Text -> Put
 putText = putByteStringLen . textToBSL

--- a/hnix-store-remote/tests/Driver.hs
+++ b/hnix-store-remote/tests/Driver.hs
@@ -1,8 +1,9 @@
 import Test.Tasty.Hspec
 import NixDaemon
+import qualified Spec
 
 -- we run remote tests in
 -- Linux namespaces to avoid interacting with systems store
 main = do
   enterNamespaces
-  hspec spec_protocol
+  Spec.main

--- a/hnix-store-remote/tests/Spec.hs
+++ b/hnix-store-remote/tests/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --generated-module=Spec #-}

--- a/hnix-store-remote/tests/Util.hs
+++ b/hnix-store-remote/tests/Util.hs
@@ -1,0 +1,13 @@
+
+module Util where
+
+import           Test.Tasty.QuickCheck
+import           Data.Text.Arbitrary
+
+import           System.Nix.Store.Remote.Util
+
+prop_TextToBSLRoundtrip x =
+    bslToText (textToBSL x) === x
+
+prop_TextToBSRoundtrip x =
+    bsToText (textToBS x) === x


### PR DESCRIPTION
For non ascii characters, the custom functions to convert text to/from bytestrings do not work as intended. They mangle the strings sent to the store, resulting in incorrect string content added to the store.
Found the bug in the serialisation of a .drv file.