### PR TITLE
[Quickfixes] Fix tests and build of hnix-store-remote

### DIFF
--- a/hnix-store-remote/tests/NixDaemon.hs
+++ b/hnix-store-remote/tests/NixDaemon.hs
@@ -202,7 +202,7 @@ spec_protocol = Hspec.around withNixDaemon $ do
       itRights "non-empty query" $ withPath $ \path -> queryAllValidPaths `shouldReturn` (HS.fromList [path])
 
     context "queryPathInfoUncached" $ do
-      itRights "queries path info" $ withPath $ queryPathInfoUncached @SHA256
+      itRights "queries path info" $ withPath $ queryPathInfoUncached
 
     context "ensurePath" $ do
       itRights "simple ensure" $ withPath $ ensurePath


### PR DESCRIPTION
- Propagate changes induced by the nar streaming code to the remote store package
- Fix a test quirk with queryPathInfoUncached
