### PR TITLE
ChangeLog updates, remote version bump

### DIFF
--- a/hnix-store-core/ChangeLog.md
+++ b/hnix-store-core/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## (unreleased) 0.3.0.0 -- 2020-XY-ZV
 
+* `System.Nix.Nar` changes API to support NAR format streaming:
+  * `buildNarIO :: FilePath -> Handle -> IO ()` - Create a NAR from a regular filesystem object, stream it out on the Handle
+  * `unpackNarIO :: Handle -> FilePath -> IO ()` - Recreate filesystem object from a NAR file accessed by the Handle
 * `StorePath` type changed to simple variant without type level
 symbolic store path root.
 * Added `makeFixedOutputPath` to `System.Nix.ReadonlyStore`
@@ -14,6 +17,7 @@ symbolic store path root.
 * Added `System.Nix.Build` module
 * Added `System.Nix.Derivation` module
 * Removed `System.Nix.Util` module, moved to `hnix-store-remote`
+* Added base64 and SHA512 hash support
 
 ## 0.2.0.0 -- 2020-03-12
 

--- a/hnix-store-remote/ChangeLog.md
+++ b/hnix-store-remote/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## (unreleased) 0.3.0.0 -- 2020-XY-ZV
 
-* Restored most store API functions
+* Restored most store API functions except `addToStoreNar`
 * Added `buildDerivation`
 
 ## 0.2.0.0 -- skipped

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -55,8 +55,6 @@ test-suite hnix-store-remote-tests
    if !flag(io-testsuite)
      buildable: False
 
-   build-tool-depends: nix:nix-daemon
-
    ghc-options:       -rtsopts -fprof-auto
    type:              exitcode-stdio-1.0
    main-is:           Driver.hs

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -1,5 +1,5 @@
 name:                hnix-store-remote
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            Remote hnix store
 description:         Implementation of the nix store using the daemon protocol.
 homepage:            https://github.com/haskell-nix/hnix-store

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -65,7 +65,7 @@ test-suite hnix-store-remote-tests
    hs-source-dirs:    tests
    build-depends:
                        attoparsec
-                     , hnix-store-core
+                     , hnix-store-core >= 0.3
                      , hnix-store-remote
                      , base
                      , base64-bytestring

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Builders.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Builders.hs
@@ -9,8 +9,8 @@ module System.Nix.Store.Remote.Builders (
   ) where
 
 import Data.Text.Lazy (Text)
-import System.Nix.Hash (Digest, NamedAlgo, SomeNamedDigest(SomeDigest))
-import System.Nix.StorePath (ContentAddressableAddress(..), NarHashMode(..))
+import System.Nix.Hash (Digest, SomeNamedDigest(SomeDigest))
+import System.Nix.StorePath (ContentAddressableAddress(..))
 
 import Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder
@@ -19,19 +19,19 @@ import qualified System.Nix.Hash
 
 -- | Marshall `ContentAddressableAddress` to `Text`
 -- in form suitable for remote protocol usage.
-buildContentAddressableAddress :: forall hashAlgo . NamedAlgo hashAlgo
-                               => ContentAddressableAddress
-                               -> Text
+buildContentAddressableAddress
+  :: ContentAddressableAddress
+  -> Text
 buildContentAddressableAddress =
-  Data.Text.Lazy.Builder.toLazyText . contentAddressableAddressBuilder @hashAlgo
+  Data.Text.Lazy.Builder.toLazyText . contentAddressableAddressBuilder
 
-contentAddressableAddressBuilder :: forall hashAlgo . NamedAlgo hashAlgo
-                               => ContentAddressableAddress
-                               -> Builder
+contentAddressableAddressBuilder
+  :: ContentAddressableAddress
+  -> Builder
 contentAddressableAddressBuilder (Text digest) =
      "text:"
   <> digestBuilder digest
-contentAddressableAddressBuilder (Fixed narHashMode (SomeDigest digest)) =
+contentAddressableAddressBuilder (Fixed _narHashMode (SomeDigest (digest :: Digest hashAlgo))) =
      "fixed:"
   <> (Data.Text.Lazy.Builder.fromText $ System.Nix.Hash.algoName @hashAlgo)
   <> digestBuilder digest


### PR DESCRIPTION
Related to #76

+ few other bits, `contentAddressableAddressBuilder` changed to reflect `contentA...Parser` change.