### PR TITLE
core: Add derivation test samples to extra-source-files

### DIFF
--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -13,7 +13,10 @@ maintainer:          shea@shealevy.com
 copyright:           2018 Shea Levy
 category:            Nix
 build-type:          Simple
-extra-source-files:  ChangeLog.md, README.md
+extra-source-files:  ChangeLog.md
+                   , README.md
+                   , tests/samples/example0.drv
+                   , tests/samples/example1.drv
 cabal-version:       >=1.10
 
 library


### PR DESCRIPTION
Noticed I forgot to add this.

Reminds me of `sdistTarball`.