### PR TITLE
hnix-store-core.cabal: use base16-bytestring >= 1

### DIFF
--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -36,7 +36,7 @@ library
   build-depends:       base >=4.10 && <5
                      , attoparsec
                      , algebraic-graphs >= 0.5 && < 0.6
-                     , base16-bytestring
+                     , base16-bytestring >= 1
                      , base64-bytestring
                      , bytestring
                      , binary

--- a/hnix-store-core/tests/Hash.hs
+++ b/hnix-store-core/tests/Hash.hs
@@ -88,7 +88,7 @@ spec_nixhash = do
       forM_ samples $ \(b16, b32, b64) -> shouldBe (B16.encode . BSL.toStrict <$> B64.decode b64 ) (Right b16)
 
     it "b32 encoded . b16 decoded should equal original b32" $
-      forM_ samples $ \(b16, b32, b64) -> shouldBe (encode $ fst $ B16.decode b16 ) b32
+      forM_ samples $ \(b16, b32, b64) -> shouldBe (encode <$> B16.decode b16) (Right b32)
 
     it "b64 encoded . b16 decoded should equal original b64" $
-      forM_ samples $ \(b16, b32, b64) -> shouldBe (B64.encode $ BSL.fromStrict $ fst $ B16.decode b16 ) b64
+      forM_ samples $ \(b16, b32, b64) -> shouldBe (B64.encode . BSL.fromStrict <$> B16.decode b16 ) (Right b64)


### PR DESCRIPTION
Regarding: https://github.com/haskell-nix/hnix-store/pull/84#pullrequestreview-550910849.

> Can you also add lower bound for base16-bytestring? My shell still reports base16-bytestring-0.1.1.7.