### PR TITLE
add basic CI functionality

### DIFF
--- a/.github/workflows/Cabal-Linux.yml
+++ b/.github/workflows/Cabal-Linux.yml
@@ -38,6 +38,10 @@ jobs:
       - name: "Install additional system packages"
         run: sudo apt install libsodium-dev
       - run: cabal v2-install tasty-discover
+      - name: "Install Nix"
+        # Still required for Store-remote test suite run
+        uses: cachix/install-nix-action@v12
+        if: matrix.packageRoot == 'hnix-store-remote'
       - run: cabal v2-configure --disable-optimization --enable-tests --enable-deterministic
         if: matrix.packageRoot == 'hnix-store-core'
       - run: |

--- a/.github/workflows/Cabal-Linux.yml
+++ b/.github/workflows/Cabal-Linux.yml
@@ -1,0 +1,43 @@
+name: "Hackage, Cabal, Linux"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "45 02 * * *"
+
+
+jobs:
+
+  build10:
+    name: "GHC"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        packageRoots: [ ./hnix-store-core, ./hnix-store-remote ]
+        ghc: [ "8.10", "8.4" ]
+    defaults:
+      run:
+        working-directory: "${{ matrix.packageRoots }}"
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Cache of ~/.cabal/packages, ~/.cabal/store and dist-newstyle"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: "${{ runner.os }}-Cabal-${{ matrix.ghc }}"
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - name: "Install additional system packages"
+        run: sudo apt install libsodium-dev
+      - run: cabal v2-install tasty-discover
+      - run: "cabal v2-configure --disable-optimization --enable-tests --enable-deterministic"
+      - run: "cabal v2-build"
+      - run: "cabal v2-test"

--- a/.github/workflows/Cabal-Linux.yml
+++ b/.github/workflows/Cabal-Linux.yml
@@ -17,11 +17,11 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        packageRoots: [ ./hnix-store-core, ./hnix-store-remote ]
+        packageRoot: [ hnix-store-core, hnix-store-remote ]
         ghc: [ "8.10", "8.4" ]
     defaults:
       run:
-        working-directory: "${{ matrix.packageRoots }}"
+        working-directory: "./${{ matrix.packageRoot }}"
     steps:
       - uses: actions/checkout@v2
       - name: "Cache of ~/.cabal/packages, ~/.cabal/store and dist-newstyle"
@@ -38,6 +38,11 @@ jobs:
       - name: "Install additional system packages"
         run: sudo apt install libsodium-dev
       - run: cabal v2-install tasty-discover
-      - run: "cabal v2-configure --disable-optimization --enable-tests --enable-deterministic"
-      - run: "cabal v2-build"
-      - run: "cabal v2-test"
+      - run: cabal v2-configure --disable-optimization --enable-tests --enable-deterministic
+        if: matrix.packageRoot == 'hnix-store-core'
+      - run: |
+          cabal v2-configure --disable-optimization --enable-tests --enable-deterministic \
+            -f io-testsuite  # Enable the Store-remote test suite
+        if: matrix.packageRoot == 'hnix-store-remote'
+      - run: cabal v2-build
+      - run: cabal v2-test

--- a/.github/workflows/On-Release-Cabal-Linux.yml
+++ b/.github/workflows/On-Release-Cabal-Linux.yml
@@ -37,6 +37,10 @@ jobs:
       - name: "Install additional system packages"
         run: sudo apt install libsodium-dev
       - run: cabal v2-install tasty-discover
+      - name: "Install Nix"
+        # Still required for Store-remote test suite run
+        uses: cachix/install-nix-action@v12
+        if: matrix.packageRoot == 'hnix-store-remote'
       - run: cabal v2-configure --disable-optimization --enable-tests --enable-deterministic
         if: matrix.packageRoot == 'hnix-store-core'
       - run: |

--- a/.github/workflows/On-Release-Cabal-Linux.yml
+++ b/.github/workflows/On-Release-Cabal-Linux.yml
@@ -10,14 +10,15 @@ jobs:
   build10:
     name: "GHC"
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
-        packageRoots: [ ./hnix-store-core, ./hnix-store-remote ]
+        packageRoot: [ hnix-store-core, hnix-store-remote ]
         # Since CI by default tests boundary GHCs, test middle versions of GHCs
         ghc: [ "8.8", "8.6"]
     defaults:
       run:
-        working-directory: "${{ matrix.packageRoots }}"
+        working-directory: "./${{ matrix.packageRoot }}"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -37,5 +38,10 @@ jobs:
         run: sudo apt install libsodium-dev
       - run: cabal v2-install tasty-discover
       - run: cabal v2-configure --disable-optimization --enable-tests --enable-deterministic
+        if: matrix.packageRoot == 'hnix-store-core'
+      - run: |
+          cabal v2-configure --disable-optimization --enable-tests --enable-deterministic \
+            -f io-testsuite  # Enable the Store-remote test suite
+        if: matrix.packageRoot == 'hnix-store-remote'
       - run: cabal v2-build
       - run: cabal v2-test

--- a/.github/workflows/On-Release-Cabal-Linux.yml
+++ b/.github/workflows/On-Release-Cabal-Linux.yml
@@ -1,0 +1,41 @@
+name: "Release testing, Hackage, Cabal, Linux"
+
+on:
+  release:
+    # created: a draft is saved, or a release or pre-release is published without previously being saved as a draft
+    types: [ created ]
+
+jobs:
+
+  build10:
+    name: "GHC"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        packageRoots: [ ./hnix-store-core, ./hnix-store-remote ]
+        # Since CI by default tests boundary GHCs, test middle versions of GHCs
+        ghc: [ "8.8", "8.6"]
+    defaults:
+      run:
+        working-directory: "${{ matrix.packageRoots }}"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Cache of ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-Cabal-${{ matrix.ghc }}
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - name: "Install additional system packages"
+        run: sudo apt install libsodium-dev
+      - run: cabal v2-install tasty-discover
+      - run: cabal v2-configure --disable-optimization --enable-tests --enable-deterministic
+      - run: cabal v2-build
+      - run: cabal v2-test


### PR DESCRIPTION
This is what can be directly ported from HNix OR Haskell-With-Nixpkgs projects.

Nix testing held back because Haskell.Lib API interface can not be ported directly into Store Nix setup. In Nix it is ugly to pass/inherit API through imports, (API passes through essentially by restating API two more times in every file layer).

Thou, Nixpkgs integration test works directly.

In the near future, I going to migrate the Nixpkgs integration test into Haskell-Nix.