### PR TITLE
Tmp override fix of cryptohash-sha512

### DIFF
--- a/hnix-store-core/cabal.project
+++ b/hnix-store-core/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/Anton-Latukha/cryptohash-sha512
+    tag: 82ffc68fdfc1ce3745368cd0ddc22cab5a76c769

--- a/hnix-store-remote/cabal.project
+++ b/hnix-store-remote/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/Anton-Latukha/cryptohash-sha512
+    tag: 82ffc68fdfc1ce3745368cd0ddc22cab5a76c769


### PR DESCRIPTION
`cryptohash-sha512` unmaintained, PR adds support of `base` 4.14 (GHC 8.10) through `cabal.project`

Closes #90.