### PR TITLE
CI: GitHub: Tmp allow broken/try to build broken Nix closures

### DIFF
--- a/.github/workflows/Optional-Nix-dev-env-main.yml
+++ b/.github/workflows/Optional-Nix-dev-env-main.yml
@@ -39,6 +39,9 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: "Determined Nix-build"
       run: nix-build ../ -A "pkgs.haskellPackages.${{ matrix.packageRoot }}"
+      env:
+        #  2020-12-22: NOTE: allowBroken ideally should be temporary.
+        NIXPKGS_ALLOW_BROKEN: "1"
 
 
 


### PR DESCRIPTION
SInce projects are broken quite frequently - introducing tmp `allowBroken` fix.
Works towards #67.