### PR TITLE
CI: GitHub: nix-build: fx target closure

### DIFF
--- a/.github/workflows/Optional-Nix-dev-env-main.yml
+++ b/.github/workflows/Optional-Nix-dev-env-main.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: "Determined Nix-build"
-      run: nix-build ../ -A "pkgs.haskellPackages.${{ matrix.packageRoot }}"
+      run: nix-build ../ -A "haskellPackages.${{ matrix.packageRoot }}"
       env:
         #  2020-12-22: NOTE: allowBroken ideally should be temporary.
         NIXPKGS_ALLOW_BROKEN: "1"


### PR DESCRIPTION
Nix builds were building Nixpkgs packages, and in the case of the Remote - the Nixpkgs that used local Core override.

Now they use the local build, and fall because of the `cryptohash-sha512` state, which already treated for Cabal with `cabal.project`, but looks like `cabal2Nix does not support those, so the builds fall.