### PR TITLE
hnix-store-{core,remote}: allow also `base16-bytestring < 1.0`

### DIFF
--- a/hnix-store-core/cabal.project
+++ b/hnix-store-core/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/Anton-Latukha/cryptohash-sha512
-    tag: 82ffc68fdfc1ce3745368cd0ddc22cab5a76c769
+    tag: 48f827eb09a73ad5ee43dd397a06ebdbf51ab856

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -39,7 +39,7 @@ library
   build-depends:       base >=4.10 && <5
                      , attoparsec
                      , algebraic-graphs >= 0.5 && < 0.6
-                     , base16-bytestring >= 1
+                     , base16-bytestring
                      , base64-bytestring
                      , bytestring
                      , binary

--- a/hnix-store-remote/cabal.project
+++ b/hnix-store-remote/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/Anton-Latukha/cryptohash-sha512
-    tag: 82ffc68fdfc1ce3745368cd0ddc22cab5a76c769
+    tag: 48f827eb09a73ad5ee43dd397a06ebdbf51ab856


### PR DESCRIPTION
When I first tried to fork & overload the `cryptohash-sha512` in `cabal.project`, I enforced the `base16-bytestring >= 1.0` requirement, that I encountered in HNix, and understood that the support of both epochs is very easy in `cryptohash-sha512` and HNix-Store with a couple of lines of CPP macros.

So this is what this PR does. Allows downstream to use any version of `base16-bytestring`, the same probably would be done in HNix.

This also simplifies things with Nixpkgs, as standard `base16-bytestring` there is `0.1.1.7`, so supporting both means Store works in Nixpkgs in any case.