### PR TITLE
allowBroken cryptohash; base16-bytestring dep epochs support

### DIFF
--- a/hnix-store-core/src/System/Nix/Internal/Hash.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Hash.hs
@@ -162,7 +162,7 @@ decodeBase :: BaseEncoding -> T.Text -> Either String (Digest a)
 #if MIN_VERSION_base16_bytestring(1,0,0)
 decodeBase Base16 = fmap Digest . Base16.decode . T.encodeUtf8
 #else
-decodeBase Base16 = lDecode  -- *this tacit sugar simply makes GHC pleased with number of args
+decodeBase Base16 = lDecode  -- this tacit sugar simply makes GHC pleased with number of args
  where
   lDecode t = case Base16.decode (T.encodeUtf8 t) of
     (x, "") -> Right $ Digest x

--- a/hnix-store-core/tests/Hash.hs
+++ b/hnix-store-core/tests/Hash.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE CPP #-}
 
 module Hash where
 
@@ -91,7 +92,19 @@ spec_nixhash = do
       forM_ samples $ \(b16, b32, b64) -> shouldBe (B16.encode . BSL.toStrict <$> B64.decode b64 ) (Right b16)
 
     it "b32 encoded . b16 decoded should equal original b32" $
-      forM_ samples $ \(b16, b32, b64) -> shouldBe (B32.encode <$> B16.decode b16) (Right b32)
+      forM_ samples $ \(b16, b32, b64) -> shouldBe (B32.encode
+#if MIN_VERSION_base16_bytestring(1,0,0)
+        <$> B16.decode b16) (Right b32)
+#else
+        $ fst $ B16.decode b16) (b32)
+
+#endif
 
     it "b64 encoded . b16 decoded should equal original b64" $
-      forM_ samples $ \(b16, b32, b64) -> shouldBe (B64.encode . BSL.fromStrict <$> B16.decode b16 ) (Right b64)
+      forM_ samples $ \(b16, b32, b64) -> shouldBe (B64.encode . BSL.fromStrict
+#if MIN_VERSION_base16_bytestring(1,0,0)
+        <$> B16.decode b16) (Right b64)
+#else
+        $ fst $ B16.decode b16 ) (b64)
+#endif
+

--- a/overlay.nix
+++ b/overlay.nix
@@ -3,4 +3,7 @@ hlib: helf: huper: {
     helf.callCabal2nix "hnix-store-core" ./hnix-store-core {};
   hnix-store-remote =
     helf.callCabal2nixWithOptions "hnix-store-remote" ./hnix-store-remote "-fio-testsuite" {};
+  #  2020-12-30: NOTE: Remove after switch from cryptohash
+  cryptohash-sha512 =
+    hlib.unmarkBroken ( hlib.doJailbreak huper.cryptohash-sha512 );
 }


### PR DESCRIPTION
* `allowBroken cryptohash` allows to check Nix dev env builds.

* Reintroduced tests to support the old `base16-bytestring` epoch, since it is trivial.