### PR TITLE
Cleanup cabal files and dependencies

### DIFF
--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.2
 name:                hnix-store-core
 version:             0.4.0.0
 synopsis:            Core effects for interacting with the Nix store.
@@ -17,9 +18,15 @@ extra-source-files:  ChangeLog.md
                    , README.md
                    , tests/samples/example0.drv
                    , tests/samples/example1.drv
-cabal-version:       >=1.10
+
+Common commons
+  if impl(ghc >= 8.10)
+    ghc-options:  -Wall -Wunused-packages
+  else
+    ghc-options:  -Wall
 
 library
+  import: commons
   exposed-modules:     System.Nix.Base32
                      , System.Nix.Build
                      , System.Nix.Derivation
@@ -71,6 +78,7 @@ Flag bounded_memory
   default: False
 
 test-suite format-tests
+  import: commons
   if flag(bounded_memory)
     cpp-options: -DBOUNDED_MEMORY
   ghc-options: -rtsopts -fprof-auto

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -104,9 +104,7 @@ test-suite format-tests
     , filepath
     , directory
     , filepath
-    , io-streams
     , process
-    , process-extras
     , tasty
     , tasty-discover
     , tasty-golden

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -67,45 +67,45 @@ library
   default-language:    Haskell2010
 
 Flag bounded_memory
-     description: Run tests of constant memory use (requires +RTS -T)
-     default: False
+  description: Run tests of constant memory use (requires +RTS -T)
+  default: False
 
 test-suite format-tests
-   if flag(bounded_memory)
-     cpp-options: -DBOUNDED_MEMORY
-   ghc-options: -rtsopts -fprof-auto
-   type: exitcode-stdio-1.0
-   main-is: Driver.hs
-   other-modules:
-       Arbitrary
-       Derivation
-       NarFormat
-       Hash
-       StorePath
-   hs-source-dirs:
-       tests
-   build-depends:
-       hnix-store-core
-     , attoparsec
-     , base
-     , base16-bytestring
-     , base64-bytestring
-     , binary
-     , bytestring
-     , containers
-     , filepath
-     , directory
-     , filepath
-     , io-streams
-     , process
-     , process-extras
-     , tasty
-     , tasty-discover
-     , tasty-golden
-     , tasty-hspec
-     , tasty-hunit
-     , tasty-quickcheck
-     , temporary
-     , text
-     , unix
-   default-language: Haskell2010
+  if flag(bounded_memory)
+    cpp-options: -DBOUNDED_MEMORY
+  ghc-options: -rtsopts -fprof-auto
+  type: exitcode-stdio-1.0
+  main-is: Driver.hs
+  other-modules:
+      Arbitrary
+      Derivation
+      NarFormat
+      Hash
+      StorePath
+  hs-source-dirs:
+      tests
+  build-depends:
+      hnix-store-core
+    , attoparsec
+    , base
+    , base16-bytestring
+    , base64-bytestring
+    , binary
+    , bytestring
+    , containers
+    , filepath
+    , directory
+    , filepath
+    , io-streams
+    , process
+    , process-extras
+    , tasty
+    , tasty-discover
+    , tasty-golden
+    , tasty-hspec
+    , tasty-hunit
+    , tasty-quickcheck
+    , temporary
+    , text
+    , unix
+  default-language: Haskell2010

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -43,14 +43,11 @@ library
                      , binary
                      , bytestring
                      , containers
-                     , filepath
                      , text
-                     , unix
                      , network
                      , nix-derivation >= 1.1.1 && <2
                      , mtl
                      , unordered-containers
-                     , filepath
                      , time
                      , hnix-store-core >= 0.4 && <0.5
                      , vector
@@ -75,7 +72,6 @@ test-suite hnix-store-remote-tests
   build-depends:     base
                    , hnix-store-core >= 0.3
                    , hnix-store-remote
-                   , attoparsec
                    , base64-bytestring
                    , binary
                    , bytestring
@@ -91,7 +87,6 @@ test-suite hnix-store-remote-tests
                    , tasty-hunit
                    , tasty-quickcheck
                    , linux-namespaces
-                   , mtl
                    , nix-derivation
                    , temporary
                    , text

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -52,44 +52,43 @@ library
   ghc-options:         -Wall
 
 test-suite hnix-store-remote-tests
-   if !flag(io-testsuite)
-     buildable: False
+  if !flag(io-testsuite)
+    buildable: False
 
-   ghc-options:       -rtsopts -fprof-auto
-   type:              exitcode-stdio-1.0
-   main-is:           Driver.hs
-   other-modules:     Derivation
-                    , NixDaemon
-                    , Spec
-                    , Util
-   hs-source-dirs:    tests
-   build-depends:
-                       attoparsec
-                     , hnix-store-core >= 0.3
-                     , hnix-store-remote
-                     , base
-                     , base64-bytestring
-                     , binary
-                     , bytestring
-                     , containers
-                     , directory
-                     , process
-                     , filepath
-                     , hspec-expectations-lifted
-                     , quickcheck-text
-                     , tasty
-                     , tasty-discover
-                     , tasty-hspec
-                     , tasty-hunit
-                     , tasty-quickcheck
-                     , linux-namespaces
-                     , mtl
-                     , nix-derivation
-                     , temporary
-                     , text
-                     , time
-                     , unix
-                     , unordered-containers
-                     , vector
-                     , which
-   default-language: Haskell2010
+  ghc-options:       -rtsopts -fprof-auto
+  type:              exitcode-stdio-1.0
+  main-is:           Driver.hs
+  other-modules:     Derivation
+                   , NixDaemon
+                   , Spec
+                   , Util
+  hs-source-dirs:    tests
+  build-depends:     base
+                   , hnix-store-core >= 0.3
+                   , hnix-store-remote
+                   , attoparsec
+                   , base64-bytestring
+                   , binary
+                   , bytestring
+                   , containers
+                   , directory
+                   , process
+                   , filepath
+                   , hspec-expectations-lifted
+                   , quickcheck-text
+                   , tasty
+                   , tasty-discover
+                   , tasty-hspec
+                   , tasty-hunit
+                   , tasty-quickcheck
+                   , linux-namespaces
+                   , mtl
+                   , nix-derivation
+                   , temporary
+                   , text
+                   , time
+                   , unix
+                   , unordered-containers
+                   , vector
+                   , which
+  default-language: Haskell2010

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.2
 name:                hnix-store-remote
 version:             0.4.0.0
 synopsis:            Remote hnix store
@@ -11,7 +12,12 @@ copyright:           2018 Richard Marko
 category:            Nix
 build-type:          Simple
 extra-source-files:  ChangeLog.md, README.md
-cabal-version:       >=1.10
+
+Common commons
+  if impl(ghc >= 8.10)
+    ghc-options:  -Wall -Wunused-packages
+  else
+    ghc-options:  -Wall
 
 flag io-testsuite
   default:
@@ -21,6 +27,7 @@ flag io-testsuite
     binaries and Linux namespace support.
 
 library
+  import: commons
   exposed-modules:     System.Nix.Store.Remote
                      , System.Nix.Store.Remote.Binary
                      , System.Nix.Store.Remote.Builders
@@ -52,6 +59,8 @@ library
   ghc-options:         -Wall
 
 test-suite hnix-store-remote-tests
+  import: commons
+
   if !flag(io-testsuite)
     buildable: False
 


### PR DESCRIPTION
Mostly due to #106 (`ListLike` was pulled by `process-extras`).

`Wall` reveals bunch of warnings, I'll go thru that next.