### PR TITLE
cabal: rm cryptohash-sha512 override

### DIFF
--- a/hnix-store-core/cabal.project
+++ b/hnix-store-core/cabal.project
@@ -1,6 +1,1 @@
 packages: .
-
-source-repository-package
-    type: git
-    location: https://github.com/Anton-Latukha/cryptohash-sha512
-    tag: 48f827eb09a73ad5ee43dd397a06ebdbf51ab856

--- a/hnix-store-remote/cabal.project
+++ b/hnix-store-remote/cabal.project
@@ -1,6 +1,1 @@
 packages: .
-
-source-repository-package
-    type: git
-    location: https://github.com/Anton-Latukha/cryptohash-sha512
-    tag: 48f827eb09a73ad5ee43dd397a06ebdbf51ab856


### PR DESCRIPTION
https://github.com/haskell-hvr/cryptohash-sha512/pull/5#issuecomment-757068529

Nixpkgs is Ok with all this, it does not import these overrides and have own separate mechanics for the overrides. Since cryptohash-sha512 package is essentially in the unmaintained state - I think it is not worth cleaning the Nixpkgs description because soon (on soon arriving 9.0) - it may be needed again in Nixpgs store, and to that time I hope we make a transiiton.