### PR TITLE
CI: Cabal: add macOS

### DIFF
--- a/.github/workflows/Cabal-macOS.yml
+++ b/.github/workflows/Cabal-macOS.yml
@@ -1,0 +1,76 @@
+name: "Hackage, Cabal, macOS"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "45 03 * * *"
+
+env:
+  cabalConfig: --enable-tests --disable-optimization --enable-deterministic
+
+jobs:
+
+  #  2021-03-12: NOTE: Please, enable uncommented working code when `remote` builds on macOS.
+  build10:
+    name: "GHC"
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        packageRoot: [ hnix-store-core ]
+        # packageRoot: [ hnix-store-core, hnix-store-remote ]
+    defaults:
+      run:
+        working-directory: "./${{ matrix.packageRoot }}"
+    steps:
+
+      - name: "Git checkout"
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: "Haskell env setup"
+        id: HaskEnvSetup
+        uses: haskell/actions/setup@v1
+        with:
+          ghc-version: '8.10'
+
+      - name: "Repository update"
+        run: cabal v2-update
+
+      - name: "Install additional system packages"
+        run: cabal v2-install tasty-discover
+
+      # # Still required for Remote
+      # - name: "Install Nix"
+      #   uses: cachix/install-nix-action@v12
+      #   if: matrix.packageRoot == 'hnix-store-remote'
+
+      # # Remote: Enabling testsuite, because it requires networking in the default Nix environment.
+      # - name: "Project-specific Cabal configuration"
+      #   if: matrix.packageRoot == 'hnix-store-remote'
+      #   run: echo "cabalConfig=$cabalConfig -f io-testsuite" >> $GITHUB_ENV
+
+      # NOTE: Freeze is for the caching
+      - name: "Configuration freeze"
+        run: cabal v2-freeze $cabalConfig
+
+      - name: "Copy freeze file to the root dir"
+        run: cp -a cabal.project.freeze ../cabal.project.freeze
+
+      - name: "Configuring GitHub cache"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.HaskEnvSetup.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ matrix.packageRoot }}-${{ runner.os }}-Cabal-${{ hashFiles( 'cabal.project.freeze' ) }}
+          restore-keys: ${{ matrix.packageRoot }}-${{ runner.os }}-Cabal-
+
+      - name: "Build"
+        run: cabal v2-build $cabalConfig
+
+      - name: "Tests"
+        run: cabal v2-test $cabalConfig


### PR DESCRIPTION
This introduces the most basic macOS check possible, defers the #108 by being the more basic requirement comparing to a more complex one. Discussed in #112 and before that in #109.