### PR TITLE
Clean-up deps

### DIFF
--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -99,12 +99,10 @@ test-suite format-tests
     , binary
     , bytestring
     , containers
-    , filepath
     , directory
     , filepath
     , process
     , tasty
-    , tasty-discover
     , tasty-golden
     , tasty-hspec
     , tasty-hunit

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -77,7 +77,6 @@ test-suite hnix-store-remote-tests
                    , hspec-expectations-lifted
                    , quickcheck-text
                    , tasty
-                   , tasty-discover
                    , tasty-hspec
                    , tasty-quickcheck
                    , linux-namespaces

--- a/overlay.nix
+++ b/overlay.nix
@@ -12,7 +12,4 @@ pkgs: hlib: helf: huper: {
           pkgs.nix
         ];
     });
-  #  2020-12-30: NOTE: Remove after switch from cryptohash
-  cryptohash-sha512 =
-    hlib.unmarkBroken ( hlib.doJailbreak huper.cryptohash-sha512 );
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,15 +1,17 @@
 pkgs: hlib: helf: huper: {
   hnix-store-core =
-    helf.callCabal2nix "hnix-store-core" ./hnix-store-core {};
+    ( helf.callCabal2nix "hnix-store-core" ./hnix-store-core {}
+    ).overrideAttrs (attrs: {
+        buildInputs = attrs.buildInputs ++ [
+          pkgs.haskellPackages.tasty-discover
+        ];
+    });
   hnix-store-remote =
-    (helf.callCabal2nixWithOptions
-      "hnix-store-remote"
-      ./hnix-store-remote
-      "-fio-testsuite"
-      {}
+    ( helf.callCabal2nixWithOptions "hnix-store-remote" ./hnix-store-remote "-fio-testsuite" {}
     ).overrideAttrs (attrs: {
         buildInputs = attrs.buildInputs ++ [
           pkgs.nix
+          pkgs.haskellPackages.tasty-discover
         ];
     });
 }


### PR DESCRIPTION
* `cryptohash-sha512` was treated in Hackage by trustees, removing override.
* Closes: #118
`tasty-discover` is not needed in `.cabal`. If one removes the installed in the env `tasty-discover` executable would receive the situation I was puzzled about when I was building Store projects: https://github.com/haskell-works/tasty-discover/issues/4, since `tasty-discover` is if it is modules are not used - it is the runtime executable dependency which needs to be supplied externally from env.
  When I created that report - the `tasty-discover` was in `.cabal`, and I mention that in that text.
  
  So now it is a runtime executable dependency, and there seems to be no support for executable dependencies in Cabal. There is only one way to support it - install it in the environment.
  And Nix can support that through derivation expansion, which is done here.