### PR TITLE
Remote: deps: use `directory`

### DIFF
--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -87,5 +87,4 @@ test-suite hnix-store-remote-tests
                    , unix
                    , unordered-containers
                    , vector
-                   , which
   default-language: Haskell2010

--- a/hnix-store-remote/tests/Derivation.hs
+++ b/hnix-store-remote/tests/Derivation.hs
@@ -21,7 +21,7 @@ import qualified Data.Text.Lazy.Builder
 import qualified Data.Vector
 import qualified System.Nix.Derivation
 import qualified System.Nix.StorePath
-import qualified System.Which
+import qualified System.Directory
 
 drvSample :: StorePath -> StorePath -> StorePath -> Derivation StorePath Text
 drvSample builder' buildScript out = Derivation {
@@ -36,7 +36,7 @@ drvSample builder' buildScript out = Derivation {
 
 withBash :: (StorePath -> MonadStore a) -> MonadStore a
 withBash action = do
-  mfp <- liftIO $ System.Which.which "bash"
+  mfp <- liftIO $ System.Directory.findExecutable "bash"
   case mfp of
     Nothing -> error "No bash executable found"
     Just fp -> do

--- a/overlay.nix
+++ b/overlay.nix
@@ -8,7 +8,9 @@ pkgs: hlib: helf: huper: {
       "-fio-testsuite"
       {}
     ).overrideAttrs (attrs: {
-        buildInputs = attrs.buildInputs ++ [ pkgs.nix pkgs.which ];
+        buildInputs = attrs.buildInputs ++ [
+          pkgs.nix
+        ];
     });
   #  2020-12-30: NOTE: Remove after switch from cryptohash
   cryptohash-sha512 =


### PR DESCRIPTION
`which` depends on TH & `shelly` which depends on a lot of things and also `directory`.

Tangent: it is useful to know that `which` is a clone of `command -v` which seems like always was in POSIX:
"The early Unix shells until the late 70s had ... only the traditional looking up of executables in $PATH" (which is `command -v`), Bourne shell (`sh`) had it also, seems like always. The `which` is a script from "3BSD (1980)" that introduced this functionality into `csh`, it stuck because of popularity of `csh` and the name being mnemonic.
`command -v` works even in `fish`, though, not being documented in it (... oh, now is).
Long story short - `command -v` is a shell builtin.

That is why declaring the requirement of `pkgs.which` in the Nix derivation overlay triggered my attention. If there is `sh` present - the `which` executable is not needed. Or for programming languages - if in OS where there is at least `POSIX.1` (1988) support (which now again includes Microsoft Windows, not mentioning others, so we can claim `POSIX.1` supported "always"), the replacement of basic `which` use is 1 call to system function.

---

POSIX API has a function named `system`:
```
NAME

    system - issue a command

SYNOPSIS

    #include <stdlib.h>

    int system(const char *command);

DESCRIPTION

    The system() function shall behave as if a child process were created using fork(), and the child process invoked the sh utility using execl() as follows:

    execl(<shell path>, "sh", "-c", command, (char *)0);
```
So the `system` function and `sh` features are isomorphic and central to the POSIX and most OSes, and so their use in programming languages is trivial.
`system` allows to run in the env any commands, so even the `command -v which` can run without the need of locating the `shell` (`system(command)`).

Knowing these 2 things allows understanding what can be done with direct use of POSIX calls, what `sh` can do - in Haskell also "should be" one-several POSIX calls away.