### PR TITLE
Core: Internal modules are internal

### DIFF
--- a/hnix-store-core/ChangeLog.md
+++ b/hnix-store-core/ChangeLog.md
@@ -2,7 +2,14 @@
 
 ## [next](https://github.com/haskell-nix/hnix-store/compare/0.4.0.0...master) 2021-MM-DD
 
-* No changes yet
+* Internal modules moved into the internal API. Please open reports to open what is needed in the public API:
+  * `System.Nix.Internal.Base32`
+  * `System.Nix.Internal.Hash`
+  * `System.Nix.Internal.Nar.Parser`
+  * `System.Nix.Internal.Nar.Streamer`
+  * `System.Nix.Internal.Nar.Effects`
+  * `System.Nix.Internal.Signature`
+  * `System.Nix.Internal.StorePath`
 
 ## [0.4.0.0](https://github.com/haskell-nix/hnix-store/compare/0.3.0.0...0.4.0.0) 2020-12-30
 

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -31,18 +31,19 @@ library
                      , System.Nix.Build
                      , System.Nix.Derivation
                      , System.Nix.Hash
-                     , System.Nix.Internal.Base32
+
+                     , System.Nix.Nar
+                     , System.Nix.ReadonlyStore
+                     , System.Nix.Signature
+                     , System.Nix.StorePath
+                     , System.Nix.StorePathMetadata
+  other-modules:       System.Nix.Internal.Base32
                      , System.Nix.Internal.Hash
                      , System.Nix.Internal.Nar.Parser
                      , System.Nix.Internal.Nar.Streamer
                      , System.Nix.Internal.Nar.Effects
                      , System.Nix.Internal.Signature
                      , System.Nix.Internal.StorePath
-                     , System.Nix.Nar
-                     , System.Nix.ReadonlyStore
-                     , System.Nix.Signature
-                     , System.Nix.StorePath
-                     , System.Nix.StorePathMetadata
   build-depends:       base >=4.10 && <5
                      , attoparsec
                      , algebraic-graphs >= 0.5 && < 0.6


### PR DESCRIPTION
Closes: https://github.com/haskell-nix/hnix-store/issues/124

This internal API is not used in Remote or HNix.