### PR TITLE
Forming release: updating changelogs, updating cabal versions

### DIFF
--- a/hnix-store-core/ChangeLog.md
+++ b/hnix-store-core/ChangeLog.md
@@ -1,8 +1,8 @@
 # Revision history for hnix-store-core
 
-## [next](https://github.com/haskell-nix/hnix-store/compare/0.4.0.0...master) 2021-MM-DD
+## [0.4.1.0](https://github.com/haskell-nix/hnix-store/compare/0.4.0.0...0.4.1.0) 2021-MM-DD
 
-* No changes yet
+* Big clean-up of dependencies.
 
 ## [0.4.0.0](https://github.com/haskell-nix/hnix-store/compare/0.3.0.0...0.4.0.0) 2020-12-30
 

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                hnix-store-core
-version:             0.4.0.0
+version:             0.4.1.0
 synopsis:            Core effects for interacting with the Nix store.
 description:
         This package contains types and functions needed to describe

--- a/hnix-store-remote/ChangeLog.md
+++ b/hnix-store-remote/ChangeLog.md
@@ -1,8 +1,9 @@
 # Revision history for hnix-store-remote
 
-## [next](https://github.com/haskell-nix/hnix-store/compare/0.4.0.0...master) 2021-MM-DD
+## [0.4.1.0](https://github.com/haskell-nix/hnix-store/compare/0.4.0.0...0.4.1.0) 2021-MM-DD
 
-* No changes yet
+* `System.Nix.Store.Remote`: module API now exports `System.Nix.Store.Remote.Types` API also
+* Big clean-up of dependencies.
 
 ## [0.4.0.0](https://github.com/haskell-nix/hnix-store/compare/0.3.0.0...0.4.0.0) 2020-12-30
 

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                hnix-store-remote
-version:             0.4.0.0
+version:             0.4.1.0
 synopsis:            Remote hnix store
 description:         Implementation of the nix store using the daemon protocol.
 homepage:            https://github.com/haskell-nix/hnix-store


### PR DESCRIPTION
Went and checked the changelog to make it into release.

Looked through diffs: https://github.com/haskell-nix/hnix-store/compare/0.4.0.0...master
Dependency enumeration is superfluous info to the user - just stated "Big deps clean-up", aka "... it is good!" thing.
The only change that is not mentioned is: [pointer](https://github.com/haskell-nix/hnix-store/compare/0.4.0.0...master#diff-9aba4fa73b66a8cc405b0bb3b8e64d92d918ae79377ff0556e60bdd78b4464b5), that is an internal change, hardly people are interested to hear it.

All other changes are changes in the test suites or purely cosmetic refactors.

Seems like `0.4.0.1` would be too little - too many changes overall, and remote got API expantion, `0.4.1.0` is safe to bless both cases for simplicity.