### PR TITLE
Help HLS to work-out monorepo: add HLS Cradle config, rm Setup.hs from Core

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,13 @@
+cradle:
+  cabal:
+    - path: "./hnix-store-core/src"
+      component: "lib:hnix-store-core"
+
+    - path: "./hnix-store-core/tests"
+      component: "hnix-store-core:test:format-tests"
+
+    - path: "./hnix-store-remote/src"
+      component: "lib:hnix-store-remote"
+
+    - path: "./hnix-store-remote/tests"
+      component: "hnix-store-remote:test:hnix-store-remote-tests"

--- a/hnix-store-core/Setup.hs
+++ b/hnix-store-core/Setup.hs
@@ -1,2 +1,0 @@
-import           Distribution.Simple
-main = defaultMain


### PR DESCRIPTION
The HLS had a problem that it was detecting the `cabal.project` in root of our
monorepo, but also was founding the Setup.hs that promised that it is a simple
project structure. And was trying to run the Core with `runhaskell`.

So HLS was throwing several errors. The explicit definition of cradles allowed
HLS to understand that it is a monorepo. Removing of Setup.hs is
because HLS sometimes was trying to run the Core with `runhaskell`.
and Setup.hs is not recommended anymore in the docs, and upstream work plans to deprecate it
completely in favor of a proper solution.
