### PR TITLE
Core, Remote: handcrafted clean-up

### DIFF
--- a/hnix-store-core/Setup.hs
+++ b/hnix-store-core/Setup.hs
@@ -1,2 +1,2 @@
-import Distribution.Simple
+import           Distribution.Simple
 main = defaultMain

--- a/hnix-store-core/src/System/Nix/Base32.hs
+++ b/hnix-store-core/src/System/Nix/Base32.hs
@@ -1,9 +1,10 @@
 {-|
 Description: Implementation of Nix's base32 encoding.
 -}
-module System.Nix.Base32 (
-    encode
+module System.Nix.Base32
+  ( encode
   , decode
-  ) where
+  )
+where
 
-import System.Nix.Internal.Base32
+import           System.Nix.Internal.Base32

--- a/hnix-store-core/src/System/Nix/Build.hs
+++ b/hnix-store-core/src/System/Nix/Build.hs
@@ -3,15 +3,16 @@
 Description : Build related types
 Maintainer  : srk <srk@48.io>
 |-}
-module System.Nix.Build (
-    BuildMode(..)
+module System.Nix.Build
+  ( BuildMode(..)
   , BuildStatus(..)
   , BuildResult(..)
   , buildSuccess
-  ) where
+  )
+where
 
-import           Data.Time                 (UTCTime)
-import           Data.Text                 (Text)
+import           Data.Time                      ( UTCTime )
+import           Data.Text                      ( Text )
 
 -- keep the order of these Enums to match enums from reference implementations
 -- src/libstore/store-api.hh
@@ -49,12 +50,9 @@ data BuildResult = BuildResult
     startTime          :: !UTCTime
   ,  -- Stop time of this build
     stopTime           :: !UTCTime
-  } deriving (Eq, Ord, Show)
+  }
+  deriving (Eq, Ord, Show)
 
 buildSuccess :: BuildResult -> Bool
-buildSuccess BuildResult{..} =
-  status `elem`
-    [ Built
-    , Substituted
-    , AlreadyValid
-    ]
+buildSuccess BuildResult {..} =
+  status `elem` [Built, Substituted, AlreadyValid]

--- a/hnix-store-core/src/System/Nix/Derivation.hs
+++ b/hnix-store-core/src/System/Nix/Derivation.hs
@@ -1,19 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module System.Nix.Derivation (
-    parseDerivation
+module System.Nix.Derivation
+  ( parseDerivation
   , buildDerivation
-  ) where
+  )
+where
 
-import           Data.Text                 (Text)
-import qualified Data.Text                 as Text
-import qualified Data.Text.Lazy.Builder    as Text.Lazy (Builder)
-import qualified Data.Text.Lazy.Builder    as Text.Lazy.Builder
-import qualified Data.Attoparsec.Text.Lazy as Text.Lazy (Parser)
-import           Nix.Derivation            (Derivation)
-import qualified Nix.Derivation            as Derivation
-import           System.Nix.StorePath      (StorePath)
-import qualified System.Nix.StorePath      as StorePath
+import           Data.Text                      ( Text )
+import qualified Data.Text                     as Text
+import qualified Data.Text.Lazy.Builder        as Text.Lazy
+                                                ( Builder )
+import qualified Data.Text.Lazy.Builder        as Text.Lazy.Builder
+import qualified Data.Attoparsec.Text.Lazy     as Text.Lazy
+                                                ( Parser )
+import           Nix.Derivation                 ( Derivation )
+import qualified Nix.Derivation                as Derivation
+import           System.Nix.StorePath           ( StorePath )
+import qualified System.Nix.StorePath          as StorePath
 
 
 

--- a/hnix-store-core/src/System/Nix/Hash.hs
+++ b/hnix-store-core/src/System/Nix/Hash.hs
@@ -1,8 +1,8 @@
 {-|
 Description : Cryptographic hashes for hnix-store.
 -}
-module System.Nix.Hash (
-    Hash.Digest
+module System.Nix.Hash
+  ( Hash.Digest
 
   , Hash.HashAlgorithm(..)
   , Hash.ValidAlgo(..)
@@ -16,6 +16,7 @@ module System.Nix.Hash (
   , Hash.BaseEncoding(..)
   , Hash.encodeInBase
   , Hash.decodeBase
-  ) where
+  )
+where
 
-import qualified System.Nix.Internal.Hash as Hash
+import qualified System.Nix.Internal.Hash      as Hash

--- a/hnix-store-core/src/System/Nix/Internal/Base32.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Base32.hs
@@ -1,18 +1,19 @@
 module System.Nix.Internal.Base32 where
 
 
-import           Data.Maybe             (fromMaybe)
-import           Data.ByteString        (ByteString)
-import qualified Data.ByteString        as Bytes
-import qualified Data.ByteString.Char8  as Bytes.Char8
+import           Data.Bool                      ( bool )
+import           Data.Maybe                     ( fromMaybe )
+import           Data.ByteString                ( ByteString )
+import qualified Data.ByteString               as Bytes
+import qualified Data.ByteString.Char8         as Bytes.Char8
 import qualified Data.Text
-import           Data.Vector            (Vector)
-import qualified Data.Vector            as Vector
-import           Data.Text              (Text)
-import           Data.Bits              (shiftR)
-import           Data.Word              (Word8)
-import           Data.List              (unfoldr)
-import           Numeric                (readInt)
+import           Data.Vector                    ( Vector )
+import qualified Data.Vector                   as Vector
+import           Data.Text                      ( Text )
+import           Data.Bits                      ( shiftR )
+import           Data.Word                      ( Word8 )
+import           Data.List                      ( unfoldr )
+import           Numeric                        ( readInt )
 
 
 -- omitted: E O U T
@@ -32,7 +33,7 @@ encode c = Data.Text.pack $ map char32 [nChar - 1, nChar - 2 .. 0]
   -- the - 1 inside of it.
   nChar = fromIntegral $ ((Bytes.length c * 8 - 1) `div` 5) + 1
 
-  byte = Bytes.index c . fromIntegral
+  byte  = Bytes.index c . fromIntegral
 
   -- May need to switch to a more efficient calculation at some
   -- point.
@@ -52,30 +53,34 @@ encode c = Data.Text.pack $ map char32 [nChar - 1, nChar - 2 .. 0]
 -- | Decode Nix's base32 encoded text
 decode :: Text -> Either String ByteString
 decode what =
-  if Data.Text.all (`elem` digits32) what
-    then unsafeDecode what
-    else Left "Invalid base32 string"
+  bool
+    (Left "Invalid Base32 string")
+    (unsafeDecode what)
+    (Data.Text.all (`elem` digits32) what)
 
 -- | Decode Nix's base32 encoded text
 -- Doesn't check if all elements match `digits32`
 unsafeDecode :: Text -> Either String ByteString
 unsafeDecode what =
-  case readInt 32
-         (`elem` digits32)
-         (\c -> fromMaybe (error "character not in digits32")
-                  $ Vector.findIndex (==c) digits32)
-         (Data.Text.unpack what)
+  case
+      readInt
+        32
+        (`elem` digits32)
+        (\c -> fromMaybe (error "character not in digits32")
+          $ Vector.findIndex (== c) digits32
+        )
+        (Data.Text.unpack what)
     of
       [(i, _)] -> Right $ padded $ integerToBS i
       x        -> Left $ "Can't decode: readInt returned " ++ show x
-  where
-    padded x
-      | Bytes.length x < decLen = x `Bytes.append` bstr
-      | otherwise = x
-     where
-      bstr = Bytes.Char8.pack $ take (decLen - Bytes.length x) (cycle "\NUL")
+ where
+  padded x
+    | Bytes.length x < decLen = x `Bytes.append` bstr
+    | otherwise               = x
+   where
+    bstr = Bytes.Char8.pack $ take (decLen - Bytes.length x) (cycle "\NUL")
 
-    decLen = Data.Text.length what * 5 `div` 8
+  decLen = Data.Text.length what * 5 `div` 8
 
 -- | Encode an Integer to a bytestring
 -- Similar to Data.Base32String (integerToBS) without `reverse`

--- a/hnix-store-core/src/System/Nix/Internal/Nar/Parser.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Nar/Parser.hs
@@ -13,7 +13,10 @@ import qualified Algebra.Graph                   as Graph
 import qualified Algebra.Graph.ToGraph           as Graph
 import qualified Control.Concurrent              as Concurrent
 import qualified Control.Exception.Lifted        as Exception.Lifted
-import           Control.Monad                   (forM, when, forM_)
+import           Control.Monad                    ( forM
+                                                  , when
+                                                  , forM_
+                                                  )
 import qualified Control.Monad.Except            as Except
 import qualified Control.Monad.Fail              as Fail
 import qualified Control.Monad.IO.Class          as IO
@@ -21,16 +24,17 @@ import qualified Control.Monad.Reader            as Reader
 import qualified Control.Monad.State             as State
 import qualified Control.Monad.Trans             as Trans
 import qualified Control.Monad.Trans.Control     as Base
-import           Data.ByteString                 (ByteString)
+import           Data.ByteString                  ( ByteString )
 import qualified Data.ByteString                 as Bytes
+import           Data.Bool                        ( bool )
 import qualified Data.Either                     as Either
-import           Data.Int                        (Int64)
+import           Data.Int                         ( Int64 )
 import qualified Data.IORef                      as IORef
 import qualified Data.List                       as List
 import qualified Data.Map                        as Map
-import           Data.Maybe                      (catMaybes)
+import           Data.Maybe                       ( catMaybes )
 import qualified Data.Serialize                  as Serialize
-import           Data.Text                       (Text)
+import           Data.Text                        ( Text )
 import qualified Data.Text                       as Text
 import qualified Data.Text.Encoding              as Text
 import qualified System.Directory                as Directory
@@ -68,7 +72,8 @@ newtype NarParser m a = NarParser
 --   This is suitable for testing the top-level NAR parser, or any of the
 --   smaller utilities parsers, if you have bytes appropriate for them
 runParser
-  :: forall m a.(IO.MonadIO m, Base.MonadBaseControl IO m)
+  :: forall m a
+   . (IO.MonadIO m, Base.MonadBaseControl IO m)
   => Nar.NarEffects m
      -- ^ Provide the effects set, usually @narEffectsIO@
   -> NarParser m a
@@ -80,9 +85,9 @@ runParser
      -- ^ The root file system object to be created by the NAR
   -> m (Either String a)
 runParser effs (NarParser action) h target = do
-  unpackResult <- Reader.runReaderT
-                  (Except.runExceptT $ State.evalStateT action state0) effs
-                  `Exception.Lifted.catch` exceptionHandler
+  unpackResult <-
+    Reader.runReaderT (Except.runExceptT $ State.evalStateT action state0) effs
+      `Exception.Lifted.catch` exceptionHandler
   when (Either.isLeft unpackResult) cleanup
   return unpackResult
 
@@ -97,15 +102,17 @@ runParser effs (NarParser action) h target = do
       }
 
   exceptionHandler :: Exception.Lifted.SomeException -> m (Either String a)
-  exceptionHandler e = return $ Left $ "Exception while unpacking NAR file: " <> show e
+  exceptionHandler e =
+    return $ Left $ "Exception while unpacking NAR file: " <> show e
 
   cleanup :: m ()
   cleanup =
-    ( \ ef trg -> do
+    (\ef trg -> do
       isDir <- Nar.narIsDir ef trg
-      if isDir
-        then Nar.narDeleteDir ef trg
-        else Nar.narDeleteFile ef trg
+      bool
+        (Nar.narDeleteFile ef trg)
+        (Nar.narDeleteDir ef trg)
+        isDir
     ) effs target
 
 
@@ -146,9 +153,9 @@ parseFSO :: (IO.MonadIO m, Fail.MonadFail m) => NarParser m ()
 parseFSO = do
   expectStr "type"
   matchStr
-    [("symlink", parseSymlink)
-    ,("regular", parseFile)
-    ,("directory", parseDirectory)
+    [ ("symlink"  , parseSymlink  )
+    , ("regular"  , parseFile     )
+    , ("directory", parseDirectory)
     ]
 
 
@@ -160,19 +167,19 @@ parseFSO = do
 parseSymlink :: (IO.MonadIO m, Fail.MonadFail m) => NarParser m ()
 parseSymlink = do
   expectStr "target"
-  target <- parseStr
-  (dir,file) <- currentDirectoryAndFile
-  pushLink $ LinkInfo
-    { linkTarget = Text.unpack target
-    , linkFile = file
-    , linkPWD = dir
-    }
+  target      <- parseStr
+  (dir, file) <- currentDirectoryAndFile
+  pushLink $
+    LinkInfo
+      { linkTarget = Text.unpack target
+      , linkFile   = file
+      , linkPWD    = dir
+      }
  where
   currentDirectoryAndFile :: Monad m => NarParser m (FilePath, FilePath)
   currentDirectoryAndFile = do
     dirStack <- State.gets directoryStack
-    return ( List.foldr1 (</>) (List.reverse $ drop 1 dirStack)
-      , head dirStack)
+    return (List.foldr1 (</>) (List.reverse $ drop 1 dirStack), head dirStack)
 
 
 -- | Internal data type representing symlinks encountered in the NAR
@@ -183,25 +190,27 @@ data LinkInfo = LinkInfo
     -- ^ file name of the link being created
   , linkPWD    :: String
     -- ^ directory in which to create the link (relative to unpacking root)
-  } deriving (Show)
+  }
+  deriving Show
 
 
 -- | When the NAR includes a file, we read from the NAR handle in chunks and
 --   write the target in chunks. This lets us avoid reading the full contents
 --   of the encoded file into memory
-parseFile :: forall m.(IO.MonadIO m, Fail.MonadFail m) => NarParser m ()
+parseFile :: forall m . (IO.MonadIO m, Fail.MonadFail m) => NarParser m ()
 parseFile = do
 
   s <- parseStr
-  when (s `notElem` ["executable", "contents"])
-       $ Fail.fail $
-         "Parser found " <> show s <> " when expecting element from "
-         <> (show :: [String] -> String) ["executable", "contents"]
+  when (s `notElem` ["executable", "contents"]) $
+    Fail.fail
+      $ "Parser found " <> show s
+      <> " when expecting element from "
+      <> (show :: [String] -> String) ["executable", "contents"]
   when (s == "executable") $ do
     expectStr ""
     expectStr "contents"
 
-  fSize <- parseLength
+  fSize        <- parseLength
 
   -- Set up for defining `getChunk`
   narHandle    <- State.gets handle
@@ -245,21 +254,21 @@ parseFile = do
 parseDirectory :: (IO.MonadIO m, Fail.MonadFail m) => NarParser m ()
 parseDirectory = do
   createDirectory <- Reader.asks Nar.narCreateDir
-  target <- currentFile
+  target          <- currentFile
   Trans.lift $ createDirectory target
   parseEntryOrFinish
 
  where
 
   parseEntryOrFinish :: (IO.MonadIO m, Fail.MonadFail m) => NarParser m ()
-  parseEntryOrFinish = do
+  parseEntryOrFinish =
     -- If we reach a ")", we finished the directory's entries, and we have
     -- to put ")" back into the stream, because the outer call to @parens@
     -- expects to consume it.
     -- Otherwise, parse an entry as a fresh file system object
     matchStr
-      [ (")",     pushStr ")")
-      , ("entry", parseEntry )
+      [ ( ")"   , pushStr ")" )
+      , ("entry", parseEntry  )
       ]
 
   parseEntry :: (IO.MonadIO m, Fail.MonadFail m) => NarParser m ()
@@ -286,13 +295,13 @@ parseStr :: (IO.MonadIO m, Fail.MonadFail m) => NarParser m Text
 parseStr = do
   cachedStr <- popStr
   case cachedStr of
-    Just str -> do
-      return str
+    Just str -> pure str
     Nothing  -> do
-      len       <- parseLength
+      len      <- parseLength
       strBytes <- consume $ fromIntegral len
-      expectRawString (Bytes.replicate (fromIntegral $ padLen $ fromIntegral len) 0)
-      return $ Text.decodeUtf8 strBytes
+      expectRawString
+        (Bytes.replicate (fromIntegral $ padLen $ fromIntegral len) 0)
+      pure $ Text.decodeUtf8 strBytes
 
 
 -- | Get an Int64 describing the length of the upcoming string,
@@ -300,38 +309,46 @@ parseStr = do
 parseLength :: (IO.MonadIO m, Fail.MonadFail m) => NarParser m Int64
 parseLength = do
   eightBytes <- consume 8
-  case Serialize.runGet Serialize.getInt64le eightBytes of
-    Left e  -> Fail.fail $ "parseLength failed to decode int64: " <> e
-    Right n -> return n
+  either
+    (\e -> Fail.fail $ "parseLength failed to decode int64: " <> e)
+    pure
+    (Serialize.runGet Serialize.getInt64le eightBytes)
 
 
 -- | Consume a NAR string and assert that it matches an expectation
 expectStr :: (IO.MonadIO m, Fail.MonadFail m) => Text -> NarParser m ()
 expectStr expected = do
   actual <- parseStr
-  when (actual /= expected)
-    (Fail.fail $ "Expected " <> err expected <> ", got " <> err actual )
+  when (actual /= expected) $
+    Fail.fail $  "Expected " <> err expected <> ", got " <> err actual
  where
   err t =
     show $
-      if Text.length t > 10
-        then Text.take 10 t
-        else t
+      bool
+        t
+        (Text.take 10 t <> "...")
+        (Text.length t > 10)
 
 
 -- | Consume a raw string and assert that it equals some expectation.
 --   This is usually used when consuming padding 0's
-expectRawString :: (IO.MonadIO m, Fail.MonadFail m) => ByteString -> NarParser m ()
+expectRawString
+  :: (IO.MonadIO m, Fail.MonadFail m) => ByteString -> NarParser m ()
 expectRawString expected = do
   actual <- consume $ Bytes.length expected
-  when (actual /= expected) $
-    Fail.fail $ "Expected " <> err expected <> ", got " <> err actual
+  when (actual /= expected)
+    $  Fail.fail
+    $  "Expected "
+    <> err expected
+    <> ", got "
+    <> err actual
  where
   err bs =
     show $
-      if Bytes.length bs > 10
-        then Bytes.take 10 bs <> "..."
-        else bs
+      bool
+        bs
+        (Bytes.take 10 bs <> "...")
+        (Bytes.length bs > 10)
 
 
 -- | Consume a NAR string, and dispatch to a parser depending on which string
@@ -344,8 +361,9 @@ matchStr
 matchStr parsers = do
   str <- parseStr
   case List.lookup str parsers of
-    Just p  -> p
-    Nothing -> Fail.fail $ "Expected one of " <> show (fst <$> parsers) <> " found " <> show str
+    Just p -> p
+    Nothing ->
+      Fail.fail $ "Expected one of " <> show (fst <$> parsers) <> " found " <> show str
 
 
 -- | Wrap any parser in NAR formatted parentheses
@@ -410,7 +428,7 @@ consume
   -> NarParser m ByteString
 consume 0 = return ""
 consume n = do
-  state0 <- State.get
+  state0   <- State.get
   newBytes <- IO.liftIO $ Bytes.hGetSome (handle state0) (max 0 n)
   when (Bytes.length newBytes < n) $
     Fail.fail $
@@ -424,8 +442,8 @@ popStr :: Monad m => NarParser m (Maybe Text)
 popStr = do
   s <- State.get
   case List.uncons (tokenStack s) of
-    Nothing     -> return Nothing
-    Just (x,xs) -> do
+    Nothing      -> return Nothing
+    Just (x, xs) -> do
       State.put $ s { tokenStack = xs }
       return $ Just x
 
@@ -439,7 +457,8 @@ pushStr str =
 
 -- | Push a level onto the directory stack
 pushFileName :: Monad m => FilePath -> NarParser m ()
-pushFileName fName = State.modify (\s -> s { directoryStack = fName : directoryStack s })
+pushFileName fName =
+  State.modify (\s -> s { directoryStack = fName : directoryStack s })
 
 
 -- | Go to the parent level in the directory stack
@@ -473,13 +492,14 @@ testParser p b = do
   tmpFileName = "tmp"
 
 testParser' :: (m ~ IO) => FilePath -> IO (Either String ())
-testParser' fp = IO.withFile fp IO.ReadMode $ \h -> runParser Nar.narEffectsIO parseNar h "tmp"
+testParser' fp =
+  IO.withFile fp IO.ReadMode $ \h -> runParser Nar.narEffectsIO parseNar h "tmp"
 
 
 
 
 -- | Distance to the next multiple of 8
-padLen:: Int -> Int
+padLen :: Int -> Int
 padLen n = (8 - n) `mod` 8
 
 

--- a/hnix-store-core/src/System/Nix/Internal/Signature.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Signature.hs
@@ -6,11 +6,11 @@ Description : Nix-relevant interfaces to NaCl signatures.
 module System.Nix.Internal.Signature where
 
 
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as Bytes
-import Data.Coerce (coerce)
-import Crypto.Saltine.Core.Sign (PublicKey)
-import Crypto.Saltine.Class (IsEncoding(..))
+import           Data.ByteString                    ( ByteString )
+import qualified Data.ByteString                   as Bytes
+import           Data.Coerce                        ( coerce )
+import           Crypto.Saltine.Core.Sign           ( PublicKey )
+import           Crypto.Saltine.Class               ( IsEncoding(..) )
 import qualified Crypto.Saltine.Internal.ByteSizes as NaClSizes
 
 
@@ -20,7 +20,7 @@ newtype Signature = Signature ByteString
 
 instance IsEncoding Signature where
   decode s
-    | Bytes.length s == NaClSizes.sign = Just (Signature s)
+    | Bytes.length s == NaClSizes.sign = Just $ Signature s
     | otherwise = Nothing
   encode = coerce
 
@@ -29,5 +29,6 @@ data NarSignature = NarSignature
   { -- | The public key used to sign the archive.
     publicKey :: PublicKey
   , -- | The archive's signature.
-    sig :: Signature
-  } deriving (Eq, Ord)
+    sig       :: Signature
+  }
+  deriving (Eq, Ord)

--- a/hnix-store-core/src/System/Nix/Nar.hs
+++ b/hnix-store-core/src/System/Nix/Nar.hs
@@ -9,7 +9,8 @@ Maintainer  : Shea Levy <shea@shealevy.com>
 {-# LANGUAGE TypeFamilies        #-}
 
 
-module System.Nix.Nar (
+module System.Nix.Nar
+  (
 
   -- * Encoding and Decoding NAR archives
     buildNarIO
@@ -27,15 +28,16 @@ module System.Nix.Nar (
   -- * Internal
   , Nar.streamNarIO
   , Nar.runParser
-  ) where
+  )
+where
 
-import qualified Control.Concurrent               as Concurrent
-import qualified Data.ByteString                  as BS
-import qualified System.IO                        as IO
+import qualified Control.Concurrent                as Concurrent
+import qualified Data.ByteString                   as BS
+import qualified System.IO                         as IO
 
-import qualified System.Nix.Internal.Nar.Effects  as Nar
-import qualified System.Nix.Internal.Nar.Parser   as Nar
-import qualified System.Nix.Internal.Nar.Streamer as Nar
+import qualified System.Nix.Internal.Nar.Effects   as Nar
+import qualified System.Nix.Internal.Nar.Parser    as Nar
+import qualified System.Nix.Internal.Nar.Streamer  as Nar
 
 
 -- For a description of the NAR format, see Eelco's thesis
@@ -64,7 +66,4 @@ unpackNarIO
   -> IO.Handle
   -> FilePath
   -> IO (Either String ())
-unpackNarIO effs =
-  Nar.runParser
-    effs
-    Nar.parseNar
+unpackNarIO effs = Nar.runParser effs Nar.parseNar

--- a/hnix-store-core/src/System/Nix/ReadonlyStore.hs
+++ b/hnix-store-core/src/System/Nix/ReadonlyStore.hs
@@ -2,41 +2,50 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
 module System.Nix.ReadonlyStore where
 
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.Text as T
-import qualified Data.HashSet as HS
+
+import           Data.ByteString                ( ByteString )
+import qualified Data.ByteString               as BS
+import qualified Data.Text                     as T
+import qualified Data.HashSet                  as HS
 import           Data.Text.Encoding
 import           System.Nix.Hash
 import           System.Nix.StorePath
 
-makeStorePath :: forall hashAlgo . (NamedAlgo hashAlgo)
+
+makeStorePath
+  :: forall hashAlgo
+   . (NamedAlgo hashAlgo)
   => FilePath
   -> ByteString
   -> Digest hashAlgo
   -> StorePathName
   -> StorePath
 makeStorePath fp ty h nm = StorePath storeHash nm fp
-  where
-    storeHash = hash s
+ where
+  storeHash = hash s
 
-    s =
-      BS.intercalate ":" $
-        ty:fmap encodeUtf8
-          [ algoName @hashAlgo
-          , encodeInBase Base16 h
-          , T.pack fp
-          , unStorePathName nm
-          ]
+  s =
+    BS.intercalate ":" $
+      ty:fmap encodeUtf8
+        [ algoName @hashAlgo
+        , encodeInBase Base16 h
+        , T.pack fp
+        , unStorePathName nm
+        ]
 
-makeTextPath :: FilePath -> StorePathName -> Digest 'SHA256 -> StorePathSet -> StorePath
+makeTextPath
+  :: FilePath -> StorePathName -> Digest 'SHA256 -> StorePathSet -> StorePath
 makeTextPath fp nm h refs = makeStorePath fp ty h nm
-  where
-    ty = BS.intercalate ":" ("text" : map storePathToRawFilePath (HS.toList refs))
+ where
+  ty =
+    BS.intercalate ":" ("text" : map storePathToRawFilePath (HS.toList refs))
 
-makeFixedOutputPath :: forall hashAlgo . (ValidAlgo hashAlgo, NamedAlgo hashAlgo)
+makeFixedOutputPath
+  :: forall hashAlgo
+   . (ValidAlgo hashAlgo, NamedAlgo hashAlgo)
   => FilePath
   -> Bool
   -> Digest hashAlgo
@@ -44,10 +53,17 @@ makeFixedOutputPath :: forall hashAlgo . (ValidAlgo hashAlgo, NamedAlgo hashAlgo
   -> StorePath
 makeFixedOutputPath fp recursive h =
   if recursive && (algoName @hashAlgo) == "sha256"
-    then makeStorePath fp "source"     h
+    then makeStorePath fp "source" h
     else makeStorePath fp "output:out" h'
  where
-  h' = hash @'SHA256 $ "fixed:out:" <> encodeUtf8 (algoName @hashAlgo) <> (if recursive then ":r:" else ":") <> encodeUtf8 (encodeInBase Base16 h) <> ":"
+  h' =
+    hash @ 'SHA256
+      $  "fixed:out:"
+      <> encodeUtf8 (algoName @hashAlgo)
+      <> (if recursive then ":r:" else ":")
+      <> encodeUtf8 (encodeInBase Base16 h)
+      <> ":"
 
-computeStorePathForText :: FilePath -> StorePathName -> ByteString -> (StorePathSet -> StorePath)
+computeStorePathForText
+  :: FilePath -> StorePathName -> ByteString -> (StorePathSet -> StorePath)
 computeStorePathForText fp nm = makeTextPath fp nm . hash

--- a/hnix-store-core/src/System/Nix/Signature.hs
+++ b/hnix-store-core/src/System/Nix/Signature.hs
@@ -4,6 +4,7 @@ Description : Nix-relevant interfaces to NaCl signatures.
 module System.Nix.Signature
   ( Signature
   , NarSignature(..)
-  ) where
+  )
+where
 
-import System.Nix.Internal.Signature
+import           System.Nix.Internal.Signature

--- a/hnix-store-core/src/System/Nix/StorePath.hs
+++ b/hnix-store-core/src/System/Nix/StorePath.hs
@@ -21,6 +21,7 @@ module System.Nix.StorePath
   , -- * Parsing 'StorePath's
     parsePath
   , pathParser
-  ) where
+  )
+where
 
-import System.Nix.Internal.StorePath
+import           System.Nix.Internal.StorePath

--- a/hnix-store-core/src/System/Nix/StorePathMetadata.hs
+++ b/hnix-store-core/src/System/Nix/StorePathMetadata.hs
@@ -3,12 +3,15 @@ Description : Metadata about Nix store paths.
 -}
 module System.Nix.StorePathMetadata where
 
-import System.Nix.StorePath (StorePath, StorePathSet, ContentAddressableAddress)
-import System.Nix.Hash (SomeNamedDigest)
-import Data.Set (Set)
-import Data.Time (UTCTime)
-import Data.Word (Word64)
-import System.Nix.Signature (NarSignature)
+import           System.Nix.StorePath           ( StorePath
+                                                , StorePathSet
+                                                , ContentAddressableAddress
+                                                )
+import           System.Nix.Hash                ( SomeNamedDigest )
+import           Data.Set                       ( Set )
+import           Data.Time                      ( UTCTime )
+import           Data.Word                      ( Word64 )
+import           System.Nix.Signature           ( NarSignature )
 
 -- | Metadata about a 'StorePath'
 data StorePathMetadata = StorePathMetadata

--- a/hnix-store-core/tests/Arbitrary.hs
+++ b/hnix-store-core/tests/Arbitrary.hs
@@ -4,9 +4,9 @@
 
 module Arbitrary where
 
-import           Control.Monad               (replicateM)
-import qualified Data.ByteString.Char8       as BSC
-import qualified Data.Text                   as T
+import           Control.Monad                  ( replicateM )
+import qualified Data.ByteString.Char8         as BSC
+import qualified Data.Text                     as T
 
 import           Test.Tasty.QuickCheck
 
@@ -22,15 +22,14 @@ nonEmptyString :: Gen String
 nonEmptyString = listOf1 genSafeChar
 
 dir :: Gen String
-dir = ('/':) <$> (listOf1 $ elements $ ('/':['a'..'z']))
+dir = ('/':) <$> (listOf1 $ elements $ '/':['a'..'z'])
 
 instance Arbitrary StorePathName where
-  arbitrary = StorePathName . T.pack
-    <$> ((:) <$> s1 <*> listOf sn)
-    where
-      alphanum = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9']
-      s1 = elements $ alphanum ++ "+-_?="
-      sn = elements $ alphanum ++ "+-._?="
+  arbitrary = StorePathName . T.pack <$> ((:) <$> s1 <*> listOf sn)
+   where
+    alphanum = ['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']
+    s1       = elements $ alphanum <> "+-_?="
+    sn       = elements $ alphanum <> "+-._?="
 
 instance Arbitrary (Digest StorePathHashAlgo) where
   arbitrary = hash . BSC.pack <$> arbitrary
@@ -41,19 +40,17 @@ instance Arbitrary (Digest 'SHA256) where
 newtype NixLike = NixLike {getNixLike :: StorePath}
  deriving (Eq, Ord, Show)
 
-instance Arbitrary (NixLike) where
-  arbitrary = NixLike <$>
-    (StorePath
-    <$> arbitraryTruncatedDigest
-    <*> arbitrary
-    <*> pure "/nix/store")
-    where
-      -- 160-bit hash, 20 bytes, 32 chars in base32
-      arbitraryTruncatedDigest = Digest . BSC.pack
-        <$> replicateM 20 genSafeChar
+instance Arbitrary NixLike where
+  arbitrary =
+    NixLike
+      <$> (StorePath
+         <$> arbitraryTruncatedDigest
+         <*> arbitrary
+         <*> pure "/nix/store"
+        )
+   where
+    -- 160-bit hash, 20 bytes, 32 chars in base32
+    arbitraryTruncatedDigest = Digest . BSC.pack <$> replicateM 20 genSafeChar
 
 instance Arbitrary StorePath where
-  arbitrary = StorePath
-           <$> arbitrary
-           <*> arbitrary
-           <*> dir
+  arbitrary = StorePath <$> arbitrary <*> arbitrary <*> dir

--- a/hnix-store-core/tests/Derivation.hs
+++ b/hnix-store-core/tests/Derivation.hs
@@ -1,10 +1,14 @@
 
 module Derivation where
 
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Golden (goldenVsFile)
+import           Test.Tasty                     ( TestTree
+                                                , testGroup
+                                                )
+import           Test.Tasty.Golden              ( goldenVsFile )
 
-import           System.Nix.Derivation (parseDerivation, buildDerivation)
+import           System.Nix.Derivation          ( parseDerivation
+                                                , buildDerivation
+                                                )
 
 import qualified Data.Attoparsec.Text.Lazy
 import qualified Data.Text.IO
@@ -14,25 +18,30 @@ import qualified Data.Text.Lazy.Builder
 processDerivation :: FilePath -> FilePath -> IO ()
 processDerivation source dest = do
   contents <- Data.Text.IO.readFile source
-  case Data.Attoparsec.Text.Lazy.parseOnly (parseDerivation "/nix/store") contents of
+  case
+    Data.Attoparsec.Text.Lazy.parseOnly
+      (parseDerivation "/nix/store")
+      contents
+    of
     Left e -> error e
     Right drv ->
-        Data.Text.IO.writeFile dest
-      . Data.Text.Lazy.toStrict
-      . Data.Text.Lazy.Builder.toLazyText
-      $ buildDerivation drv
+      Data.Text.IO.writeFile dest
+        . Data.Text.Lazy.toStrict
+        . Data.Text.Lazy.Builder.toLazyText
+        $ buildDerivation drv
 
 test_derivation :: TestTree
-test_derivation = testGroup "golden" $ map mk [0..1]
-  where
-    mk :: Int -> TestTree
-    mk n =
-      let
-        fp = "tests/samples/example"
-        drv = (fp ++ show n ++ ".drv")
-        act = (fp ++ show n ++ ".actual")
-      in
-        goldenVsFile
-          ("derivation roundtrip of " ++ drv)
-          drv act (processDerivation drv act)
-
+test_derivation =
+  testGroup "golden" $ fmap mk [0 .. 1]
+ where
+  mk :: Int -> TestTree
+  mk n =
+    goldenVsFile
+      ("derivation roundtrip of " <> drv)
+      drv
+      act
+      (processDerivation drv act)
+   where
+    drv = fp <> show n <> ".drv"
+    act = fp <> show n <> ".actual"
+    fp  = "tests/samples/example"

--- a/hnix-store-core/tests/StorePath.hs
+++ b/hnix-store-core/tests/StorePath.hs
@@ -24,10 +24,8 @@ prop_storePathRoundtrip' x =
 
 prop_storePathRoundtripParser :: NixLike -> NixLike -> Property
 prop_storePathRoundtripParser (_ :: NixLike) = \(NixLike x) ->
-  (Data.Attoparsec.Text.Lazy.parseOnly (pathParser (storePathRoot x))
-    $ storePathToText x) === Right x
+  (Data.Attoparsec.Text.Lazy.parseOnly (pathParser $ storePathRoot x) $ storePathToText x) === Right x
 
 prop_storePathRoundtripParser' :: StorePath -> Property
 prop_storePathRoundtripParser' x =
-  (Data.Attoparsec.Text.Lazy.parseOnly (pathParser (storePathRoot x))
-    $ storePathToText x) === Right x
+  (Data.Attoparsec.Text.Lazy.parseOnly (pathParser $ storePathRoot x) $ storePathToText x) === Right x

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Binary.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Binary.hs
@@ -7,8 +7,8 @@ module System.Nix.Store.Remote.Binary where
 import           Control.Monad
 import           Data.Binary.Get
 import           Data.Binary.Put
-import           Data.ByteString      (ByteString)
-import qualified Data.ByteString.Lazy as BSL
+import           Data.ByteString                ( ByteString )
+import qualified Data.ByteString.Lazy          as BSL
 
 putInt :: Integral a => a -> Put
 putInt = putWord64le . fromIntegral
@@ -31,12 +31,11 @@ putByteStringLen :: BSL.ByteString -> Put
 putByteStringLen x = do
   putInt len
   putLazyByteString x
-  when (len `mod` 8 /= 0) $
-    pad $ 8 - (len `mod` 8)
-  where
-    len :: Int
-    len = fromIntegral $ BSL.length x
-    pad count = sequence_ $ replicate count (putWord8 0)
+  when (len `mod` 8 /= 0) $ pad $ 8 - (len `mod` 8)
+ where
+  len :: Int
+  len = fromIntegral $ BSL.length x
+  pad count = sequence_ $ replicate count (putWord8 0)
 
 putByteStrings :: Foldable t => t BSL.ByteString -> Put
 putByteStrings = putMany putByteStringLen
@@ -44,10 +43,10 @@ putByteStrings = putMany putByteStringLen
 getByteStringLen :: Get ByteString
 getByteStringLen = do
   len <- getInt
-  st <- getLazyByteString len
+  st  <- getLazyByteString len
   when (len `mod` 8 /= 0) $ do
     pads <- unpad $ fromIntegral $ 8 - (len `mod` 8)
-    unless (all (==0) pads) $ fail $ "No zeroes" ++ show (st, len, pads)
+    unless (all (== 0) pads) $ fail $ "No zeroes" ++ show (st, len, pads)
   return $ BSL.toStrict st
   where unpad x = sequence $ replicate x getWord8
 

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Builders.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Builders.hs
@@ -4,42 +4,38 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module System.Nix.Store.Remote.Builders (
-    buildContentAddressableAddress
-  ) where
+module System.Nix.Store.Remote.Builders
+  ( buildContentAddressableAddress
+  )
+where
 
-import Data.Text.Lazy (Text)
-import System.Nix.Hash ( Digest
-                       , SomeNamedDigest(SomeDigest)
-                       , BaseEncoding(Base32)
-                       )
-import System.Nix.StorePath (ContentAddressableAddress(..))
+import           Data.Text.Lazy                 ( Text )
+import           System.Nix.Hash                ( Digest
+                                                , SomeNamedDigest(SomeDigest)
+                                                , BaseEncoding(Base32)
+                                                )
+import           System.Nix.StorePath           ( ContentAddressableAddress(..)
+                                                )
 
-import Data.Text.Lazy.Builder (Builder)
+import           Data.Text.Lazy.Builder         ( Builder )
 import qualified Data.Text.Lazy.Builder
 
 import qualified System.Nix.Hash
 
 -- | Marshall `ContentAddressableAddress` to `Text`
 -- in form suitable for remote protocol usage.
-buildContentAddressableAddress
-  :: ContentAddressableAddress
-  -> Text
+buildContentAddressableAddress :: ContentAddressableAddress -> Text
 buildContentAddressableAddress =
   Data.Text.Lazy.Builder.toLazyText . contentAddressableAddressBuilder
 
-contentAddressableAddressBuilder
-  :: ContentAddressableAddress
-  -> Builder
+contentAddressableAddressBuilder :: ContentAddressableAddress -> Builder
 contentAddressableAddressBuilder (Text digest) =
-     "text:"
-  <> digestBuilder digest
+  "text:" <> digestBuilder digest
 contentAddressableAddressBuilder (Fixed _narHashMode (SomeDigest (digest :: Digest hashAlgo))) =
-     "fixed:"
+  "fixed:"
   <> (Data.Text.Lazy.Builder.fromText $ System.Nix.Hash.algoName @hashAlgo)
   <> digestBuilder digest
 
 digestBuilder :: Digest a -> Builder
 digestBuilder =
-    Data.Text.Lazy.Builder.fromText
-  . System.Nix.Hash.encodeInBase Base32
+  Data.Text.Lazy.Builder.fromText . System.Nix.Hash.encodeInBase Base32

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Logger.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Logger.hs
@@ -1,20 +1,24 @@
 {-# LANGUAGE RankNTypes #-}
-module System.Nix.Store.Remote.Logger (
-    Logger(..)
+
+module System.Nix.Store.Remote.Logger
+  ( Logger(..)
   , Field(..)
-  , processOutput)
-  where
+  , processOutput
+  )
+where
+
 
 import           Control.Monad.Except
-import           Control.Monad.Reader      (ask)
-import           Control.Monad.State       (get)
+import           Control.Monad.Reader           ( asks )
+import           Control.Monad.State            ( get )
 import           Data.Binary.Get
 
-import           Network.Socket.ByteString (recv)
+import           Network.Socket.ByteString      ( recv )
 
 import           System.Nix.Store.Remote.Binary
 import           System.Nix.Store.Remote.Types
 import           System.Nix.Store.Remote.Util
+
 
 controlParser :: Get Logger
 controlParser = do
@@ -24,43 +28,51 @@ controlParser = do
     0x64617461 -> Read          <$> getInt
     0x64617416 -> Write         <$> getByteStringLen
     0x616c7473 -> pure Last
-    0x63787470 -> flip Error    <$> getByteStringLen <*> getInt
-    0x53545254 -> StartActivity <$> getInt <*> getInt <*> getInt <*> getByteStringLen <*> getFields <*> getInt
+    0x63787470 -> flip Error    <$> getByteStringLen
+                                <*> getInt
+    0x53545254 -> StartActivity <$> getInt
+                                <*> getInt
+                                <*> getInt
+                                <*> getByteStringLen
+                                <*> getFields
+                                <*> getInt
     0x53544f50 -> StopActivity  <$> getInt
-    0x52534c54 -> Result        <$> getInt <*> getInt <*> getFields
-    x          -> fail           $ "Invalid control message received:" ++ show x
+    0x52534c54 -> Result        <$> getInt
+                                <*> getInt
+                                <*> getFields
+    x          -> fail          $ "Invalid control message received:" <> show x
 
 processOutput :: MonadStore [Logger]
 processOutput = go decoder
-  where decoder = runGetIncremental controlParser
-        go :: Decoder Logger -> MonadStore [Logger]
-        go (Done _leftover _consumed ctrl) = do
-          case ctrl of
-            e@(Error _ _) -> return [e]
-            Last -> return [Last]
-            Read _n -> do
-              (mdata, _) <- get
-              case mdata of
-                Nothing -> throwError "No data to read provided"
-                Just part -> do
-                  -- XXX: we should check/assert part size against n of (Read n)
-                  sockPut $ putByteStringLen part
-                  clearData
+ where
+  decoder = runGetIncremental controlParser
+  go :: Decoder Logger -> MonadStore [Logger]
+  go (Done _leftover _consumed ctrl) = do
+    case ctrl of
+      e@(Error _ _) -> return [e]
+      Last          -> return [Last]
+      Read _n       -> do
+        (mdata, _) <- get
+        case mdata of
+          Nothing   -> throwError "No data to read provided"
+          Just part -> do
+            -- XXX: we should check/assert part size against n of (Read n)
+            sockPut $ putByteStringLen part
+            clearData
 
-              next <- go decoder
-              return $ next
+        next <- go decoder
+        return next
 
-            -- we should probably handle Read here as well
-            x -> do
-              next <- go decoder
-              return $ x:next
-        go (Partial k) = do
-          soc <- storeSocket <$> ask
-          chunk <- liftIO (Just <$> recv soc 8)
-          go (k chunk)
+      -- we should probably handle Read here as well
+      x -> do
+        next <- go decoder
+        return $ x : next
+  go (Partial k) = do
+    soc   <- asks storeSocket
+    chunk <- liftIO (Just <$> recv soc 8)
+    go (k chunk)
 
-        go (Fail _leftover _consumed msg) = do
-          error msg
+  go (Fail _leftover _consumed msg) = error msg
 
 getFields :: Get [Field]
 getFields = do
@@ -73,4 +85,4 @@ getField = do
   case (typ :: Int) of
     0 -> LogInt <$> getInt
     1 -> LogStr <$> getByteStringLen
-    x -> fail $ "Unknown log type: " ++ show x
+    x -> fail $ "Unknown log type: " <> show x

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Parsers.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Parsers.hs
@@ -13,7 +13,7 @@ where
 import           Control.Applicative            ( (<|>) )
 import           Data.Attoparsec.ByteString.Char8
 import           Data.ByteString.Char8
-import           Data.Text                      (Text)
+import           Data.Text                      ( Text )
 import           Data.Text.Encoding             ( decodeUtf8 )
 import           System.Nix.Hash
 import           System.Nix.StorePath           ( ContentAddressableAddress(..)
@@ -49,7 +49,8 @@ parseTypedDigest :: Parser (Either String SomeNamedDigest)
 parseTypedDigest = mkNamedDigest <$> parseHashType <*> parseHash
 
 parseHashType :: Parser Text
-parseHashType = decodeUtf8 <$> ("sha256" <|> "sha512" <|> "sha1" <|> "md5") <* (":" <|> "-")
+parseHashType =
+  decodeUtf8 <$> ("sha256" <|> "sha512" <|> "sha1" <|> "md5") <* (":" <|> "-")
 
 parseHash :: Parser Text
 parseHash = decodeUtf8 <$> takeWhile1 (/= ':')

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module System.Nix.Store.Remote.Types (
-    MonadStore
+module System.Nix.Store.Remote.Types
+  ( MonadStore
   , StoreConfig(..)
   , Logger(..)
   , Field(..)
@@ -14,22 +14,27 @@ module System.Nix.Store.Remote.Types (
   , getError
   , setData
   , clearData
-  ) where
+  )
+where
 
 
-import           Data.ByteString           (ByteString)
-import qualified Data.ByteString.Lazy      as BSL
-import           Network.Socket            (Socket)
+import           Data.ByteString                ( ByteString )
+import qualified Data.ByteString.Lazy          as BSL
+import           Network.Socket                 ( Socket )
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State
 
-data StoreConfig = StoreConfig {
-    storeDir        :: FilePath
-  , storeSocket     :: Socket
+data StoreConfig = StoreConfig
+  { storeDir    :: FilePath
+  , storeSocket :: Socket
   }
 
-type MonadStore a = ExceptT String (StateT (Maybe BSL.ByteString, [Logger]) (ReaderT StoreConfig IO)) a
+type MonadStore a
+  = ExceptT
+      String
+      (StateT (Maybe BSL.ByteString, [Logger]) (ReaderT StoreConfig IO))
+      a
 
 type ActivityID = Int
 type ActivityParentID = Int

--- a/hnix-store-remote/tests/Driver.hs
+++ b/hnix-store-remote/tests/Driver.hs
@@ -1,4 +1,4 @@
-import NixDaemon
+import           NixDaemon
 import qualified Spec
 
 -- we run remote tests in

--- a/hnix-store-remote/tests/Util.hs
+++ b/hnix-store-remote/tests/Util.hs
@@ -6,9 +6,7 @@ import           System.Nix.Store.Remote.Util
 import           Test.Tasty.QuickCheck
 
 prop_TextToBSLRoundtrip :: Text -> Property
-prop_TextToBSLRoundtrip x =
-    bslToText (textToBSL x) === x
+prop_TextToBSLRoundtrip x = bslToText (textToBSL x) === x
 
 prop_TextToBSRoundtrip :: Text -> Property
-prop_TextToBSRoundtrip x =
-    bsToText (textToBS x) === x
+prop_TextToBSRoundtrip x = bsToText (textToBS x) === x


### PR DESCRIPTION
First, `brittany` was used.

All changes that `brittany` were suggesting were passed through manual supervision.

Then handcrafted code cleanup was done: basic: indentation & sectioning, removal of the `do` where they are vacuous, `bool`, `either` use.

All changes are pure lambda code refactoring, there should be no changes to the functionality.