### PR TITLE
Add `GHC.Stats` import to NarFormat test

### DIFF
--- a/hnix-store-core/tests/NarFormat.hs
+++ b/hnix-store-core/tests/NarFormat.hs
@@ -38,6 +38,9 @@ import qualified Text.Printf                      as Printf
 import qualified System.Nix.Internal.Nar.Streamer as Nar
 import           System.Nix.Nar
 
+#ifdef BOUNDED_MEMORY
+import GHC.Stats
+#endif
 
 
 withBytesAsHandle :: BSLC.ByteString -> (IO.Handle -> IO a) -> IO a


### PR DESCRIPTION
This is needed for the tests to compile on my system.
Without the import, `max_live_bytes` and `getRTSStats` are undefined.