### PR TITLE
replace the filepath argument in `addToStore` with a more common type `NarSource` (The core part)

### DIFF
--- a/hnix-store-core/src/System/Nix/Internal/Nar/Streamer.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Nar/Streamer.hs
@@ -66,7 +66,7 @@ streamNarIO effs basePath yield = do
       fSize <- IO.liftIO $ Nar.narFileSize effs path
       yield $ str "contents"
       yield $ int fSize
-      yieldFile path fSize 
+      yieldFile path fSize
 
     when isDir $ do
       fs <- IO.liftIO (Nar.narListDir effs path)

--- a/hnix-store-core/src/System/Nix/Internal/Nar/Streamer.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Nar/Streamer.hs
@@ -5,6 +5,7 @@
 module System.Nix.Internal.Nar.Streamer
   ( NarSource 
   , dumpString
+  , dumpPath
   , streamNarIO
   , IsExecutable(..)
   )
@@ -25,6 +26,7 @@ import qualified System.Nix.Internal.Nar.Effects as Nar
 -- the source to provide nar to the handler
 type NarSource m =  (ByteString -> m ()) -> m ()
 
+
 -- | dumpString
 -- dump a string to nar
 dumpString :: forall m . IO.MonadIO m => ByteString -> NarSource m
@@ -36,6 +38,13 @@ dumpString text yield = do
   yield $ str "contents"
   yield $ str text
   yield $ str ")"
+
+
+-- | dumpPath
+-- shorthand
+-- build a Source that turn file path to nar using the default narEffectsIO.
+dumpPath :: forall m . IO.MonadIO m => FilePath -> NarSource m
+dumpPath = streamNarIO Nar.narEffectsIO
 
 
 -- | This implementation of Nar encoding takes an arbitrary @yield@

--- a/hnix-store-core/src/System/Nix/Nar.hs
+++ b/hnix-store-core/src/System/Nix/Nar.hs
@@ -26,6 +26,9 @@ module System.Nix.Nar
   -- * Internal
   , Nar.streamNarIO
   , Nar.runParser
+
+  -- * Type
+  , Nar.NarSource
   )
 where
 
@@ -52,9 +55,9 @@ buildNarIO
   -> IO ()
 buildNarIO effs basePath outHandle =
   Nar.streamNarIO
-    (\chunk -> BS.hPut outHandle chunk >> Concurrent.threadDelay 10)
     effs
     basePath
+    (\chunk -> BS.hPut outHandle chunk >> Concurrent.threadDelay 10)
 
 
 -- | Read NAR formatted bytes from the @IO.Handle@ and unpack them into

--- a/hnix-store-core/src/System/Nix/Nar.hs
+++ b/hnix-store-core/src/System/Nix/Nar.hs
@@ -27,6 +27,7 @@ module System.Nix.Nar
   , Nar.streamNarIO
   , Nar.runParser
   , Nar.dumpString
+  , Nar.dumpPath
 
   -- * Type
   , Nar.NarSource

--- a/hnix-store-core/src/System/Nix/Nar.hs
+++ b/hnix-store-core/src/System/Nix/Nar.hs
@@ -26,6 +26,7 @@ module System.Nix.Nar
   -- * Internal
   , Nar.streamNarIO
   , Nar.runParser
+  , Nar.dumpString
 
   -- * Type
   , Nar.NarSource

--- a/hnix-store-core/src/System/Nix/ReadonlyStore.hs
+++ b/hnix-store-core/src/System/Nix/ReadonlyStore.hs
@@ -87,7 +87,7 @@ computeStorePathForPath name pth recursive _pathFilter _repair = do
   recursiveContentHash :: IO (Digest SHA256)
   recursiveContentHash = hashFinalize <$> execStateT streamNarUpdate (hashInit @SHA256)
   streamNarUpdate :: StateT (Context SHA256) IO ()
-  streamNarUpdate = streamNarIO (modify . flip (hashUpdate @ByteString @SHA256)) narEffectsIO pth
+  streamNarUpdate = streamNarIO narEffectsIO pth (modify . flip (hashUpdate @ByteString @SHA256))
 
   flatContentHash :: IO (Digest SHA256)
   flatContentHash = hashlazy <$> narReadFile narEffectsIO pth


### PR DESCRIPTION
`type NarSource m =  (ByteString -> m ()) -> m ()`.
* `FilePath` can turn to `NarSource m`.
* `Text` can turn to `NarSource m`

So It could fix #176