### PR TITLE
Do not store the store dir in the store path

### DIFF
--- a/hnix-store-core/ChangeLog.md
+++ b/hnix-store-core/ChangeLog.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## Unreleased 202y-mm-dd
+
+* Breaking:
+    * [(link)](https://github.com/haskell-nix/hnix-store/pull/216) `StorePath` no longer carries `storePathRoot` field and we
+      have a stand-alone `StoreDir` type instead to be used instead of `FilePath`
+      when store root directory is needed as a context.
+
 ## [0.6.1.0](https://github.com/haskell-nix/hnix-store/compare/core-0.6.0.0...core-0.6.1.0) 2023-01-02
 
 * Fixed:

--- a/hnix-store-core/src/System/Nix/Derivation.hs
+++ b/hnix-store-core/src/System/Nix/Derivation.hs
@@ -11,19 +11,22 @@ import qualified Data.Attoparsec.Text.Lazy     as Text.Lazy
                                                 ( Parser )
 import           Nix.Derivation                 ( Derivation )
 import qualified Nix.Derivation                as Derivation
-import           System.Nix.StorePath           ( StorePath )
+import           System.Nix.StorePath           ( StoreDir
+                                                , StorePath
+                                                , storePathToFilePath
+                                                )
 import qualified System.Nix.StorePath          as StorePath
 
 
 
-parseDerivation :: FilePath -> Text.Lazy.Parser (Derivation StorePath Text)
+parseDerivation :: StoreDir -> Text.Lazy.Parser (Derivation StorePath Text)
 parseDerivation expectedRoot =
   Derivation.parseDerivationWith
     ("\"" *> StorePath.pathParser expectedRoot <* "\"")
     Derivation.textParser
 
-buildDerivation :: Derivation StorePath Text -> Text.Lazy.Builder
-buildDerivation =
+buildDerivation :: StoreDir -> Derivation StorePath Text -> Text.Lazy.Builder
+buildDerivation storeDir =
   Derivation.buildDerivationWith
-    (show . show)
+    (show . storePathToFilePath storeDir)
     show

--- a/hnix-store-core/src/System/Nix/Internal/StorePath.hs
+++ b/hnix-store-core/src/System/Nix/Internal/StorePath.hs
@@ -204,7 +204,7 @@ parsePath expectedRoot x =
         then pure rootDir'
         else Left $ "Root store dir mismatch, expected" <> expectedRootS <> "got" <> rootDir'
   in
-    StorePath <$> coerce storeHash <*> name
+    either Left (pure $ StorePath <$> coerce storeHash <*> name) storeDir
 
 pathParser :: StoreDir -> Parser StorePath
 pathParser expectedRoot = do

--- a/hnix-store-core/src/System/Nix/Internal/StorePath.hs
+++ b/hnix-store-core/src/System/Nix/Internal/StorePath.hs
@@ -33,7 +33,6 @@ module System.Nix.Internal.StorePath
 where
 
 import qualified Relude.Unsafe as Unsafe
-import qualified Text.Show
 import           System.Nix.Internal.Hash
 import           System.Nix.Internal.Base
 import qualified System.Nix.Internal.Base32    as Nix.Base32

--- a/hnix-store-core/src/System/Nix/Internal/StorePath.hs
+++ b/hnix-store-core/src/System/Nix/Internal/StorePath.hs
@@ -10,7 +10,8 @@ Description : Representation of Nix store paths.
 
 module System.Nix.Internal.StorePath
   ( -- * Basic store path types
-    StorePath(..)
+    StoreDir(..)
+  , StorePath(..)
   , StorePathName(..)
   , StorePathSet
   , mkStorePathHashPart
@@ -54,10 +55,9 @@ import           Crypto.Hash                    ( SHA256
 -- From the Nix thesis: A store path is the full path of a store
 -- object. It has the following anatomy: storeDir/hashPart-name.
 --
--- @storeDir@: The root of the Nix store (e.g. \/nix\/store).
---
--- See the 'StoreDir' haddocks for details on why we represent this at
--- the type level.
+-- The store directory is *not* included, and must be known from the
+-- context. This matches modern C++ Nix, and also represents the fact
+-- that store paths for different store directories cannot be mixed.
 data StorePath = StorePath
   { -- | The 160-bit hash digest reflecting the "address" of the name.
     -- Currently, this is a truncated SHA256 hash.
@@ -66,17 +66,12 @@ data StorePath = StorePath
     -- this is typically the package name and version (e.g.
     -- hello-1.2.3).
     storePathName :: !StorePathName
-  , -- | Root of the store
-    storePathRoot :: !FilePath
   }
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
 instance Hashable StorePath where
   hashWithSalt s StorePath{..} =
     s `hashWithSalt` storePathHash `hashWithSalt` storePathName
-
-instance Show StorePath where
-  show p = Bytes.Char8.unpack $ storePathToRawFilePath p
 
 -- | The name portion of a Nix path.
 --
@@ -86,7 +81,7 @@ instance Show StorePath where
 newtype StorePathName = StorePathName
   { -- | Extract the contents of the name.
     unStorePathName :: Text
-  } deriving (Eq, Hashable, Ord)
+  } deriving (Eq, Hashable, Ord, Show)
 
 -- | The hash algorithm used for store path hashes.
 newtype StorePathHashPart = StorePathHashPart ByteString
@@ -161,22 +156,29 @@ validStorePathNameChar c =
 -- to avoid the dependency.
 type RawFilePath = ByteString
 
+-- | The path to the store dir
+--
+-- Many operations need to be parameterized with this, since store paths
+-- do not know their own store dir by design.
+newtype StoreDir = StoreDir {
+    unStoreDir :: RawFilePath
+  } deriving (Eq, Hashable, Ord, Show)
+
 -- | Render a 'StorePath' as a 'RawFilePath'.
-storePathToRawFilePath :: StorePath -> RawFilePath
-storePathToRawFilePath StorePath{..} =
-  root <> "/" <> hashPart <> "-" <> name
+storePathToRawFilePath :: StoreDir -> StorePath -> RawFilePath
+storePathToRawFilePath storeDir StorePath{..} =
+  unStoreDir storeDir <> "/" <> hashPart <> "-" <> name
  where
-  root     = Bytes.Char8.pack storePathRoot
   hashPart = encodeUtf8 $ encodeWith NixBase32 $ coerce storePathHash
   name     = encodeUtf8 $ unStorePathName storePathName
 
 -- | Render a 'StorePath' as a 'FilePath'.
-storePathToFilePath :: StorePath -> FilePath
-storePathToFilePath = Bytes.Char8.unpack . storePathToRawFilePath
+storePathToFilePath :: StoreDir -> StorePath -> FilePath
+storePathToFilePath storeDir = Bytes.Char8.unpack . storePathToRawFilePath storeDir
 
 -- | Render a 'StorePath' as a 'Text'.
-storePathToText :: StorePath -> Text
-storePathToText = toText . Bytes.Char8.unpack . storePathToRawFilePath
+storePathToText :: StoreDir -> StorePath -> Text
+storePathToText storeDir = toText . Bytes.Char8.unpack . storePathToRawFilePath storeDir
 
 -- | Build `narinfo` suffix from `StorePath` which
 -- can be used to query binary caches.
@@ -186,7 +188,7 @@ storePathToNarInfo StorePath{..} =
 
 -- | Parse `StorePath` from `Bytes.Char8.ByteString`, checking
 -- that store directory matches `expectedRoot`.
-parsePath :: FilePath -> Bytes.Char8.ByteString -> Either String StorePath
+parsePath :: StoreDir -> Bytes.Char8.ByteString -> Either String StorePath
 parsePath expectedRoot x =
   let
     (rootDir, fname) = FilePath.splitFileName . Bytes.Char8.unpack $ x
@@ -196,17 +198,20 @@ parsePath expectedRoot x =
     --rootDir' = dropTrailingPathSeparator rootDir
     -- cannot use ^^ as it drops multiple slashes /a/b/// -> /a/b
     rootDir' = Unsafe.init rootDir
+    expectedRootS = Bytes.Char8.unpack (unStoreDir expectedRoot)
     storeDir =
-      if expectedRoot == rootDir'
+      if expectedRootS == rootDir'
         then pure rootDir'
-        else Left $ "Root store dir mismatch, expected" <> expectedRoot <> "got" <> rootDir'
+        else Left $ "Root store dir mismatch, expected" <> expectedRootS <> "got" <> rootDir'
   in
-    StorePath <$> coerce storeHash <*> name <*> storeDir
+    StorePath <$> coerce storeHash <*> name
 
-pathParser :: FilePath -> Parser StorePath
+pathParser :: StoreDir -> Parser StorePath
 pathParser expectedRoot = do
+  let expectedRootS = Bytes.Char8.unpack (unStoreDir expectedRoot)
+
   _ <-
-    Parser.Text.Lazy.string (toText expectedRoot)
+    Parser.Text.Lazy.string (toText expectedRootS)
       <?> "Store root mismatch" -- e.g. /nix/store
 
   _ <- Parser.Text.Lazy.char '/'
@@ -232,4 +237,4 @@ pathParser expectedRoot = do
   either
     fail
     pure
-    (StorePath <$> coerce digest <*> name <*> pure expectedRoot)
+    (StorePath <$> coerce digest <*> name)

--- a/hnix-store-core/src/System/Nix/StorePath.hs
+++ b/hnix-store-core/src/System/Nix/StorePath.hs
@@ -3,7 +3,8 @@ Description : Representation of Nix store paths.
 -}
 module System.Nix.StorePath
   ( -- * Basic store path types
-    StorePath(..)
+    StoreDir(..)
+  , StorePath(..)
   , StorePathName(..)
   , StorePathSet
   , mkStorePathHashPart

--- a/hnix-store-core/tests/Arbitrary.hs
+++ b/hnix-store-core/tests/Arbitrary.hs
@@ -35,23 +35,24 @@ instance Arbitrary StorePathHashPart where
 instance Arbitrary (Digest SHA256) where
   arbitrary = hash . BSC.pack <$> arbitrary
 
+instance Arbitrary StoreDir where
+  arbitrary = StoreDir . ("/" <>) . BSC.pack <$> arbitrary
+
 newtype NixLike = NixLike {getNixLike :: StorePath}
  deriving (Eq, Ord, Show)
 
 instance Arbitrary NixLike where
   arbitrary =
     NixLike <$>
-      liftA3 StorePath
+      liftA2 StorePath
         arbitraryTruncatedDigest
         arbitrary
-        (pure "/nix/store")
    where
     -- 160-bit hash, 20 bytes, 32 chars in base32
     arbitraryTruncatedDigest = coerce . BSC.pack <$> replicateM 20 genSafeChar
 
 instance Arbitrary StorePath where
   arbitrary =
-    liftA3 StorePath
+    liftA2 StorePath
       arbitrary
       arbitrary
-      dir

--- a/hnix-store-core/tests/Derivation.hs
+++ b/hnix-store-core/tests/Derivation.hs
@@ -6,6 +6,7 @@ import           Test.Tasty                     ( TestTree
                                                 )
 import           Test.Tasty.Golden              ( goldenVsFile )
 
+import           System.Nix.StorePath           ( StoreDir(..) )
 import           System.Nix.Derivation          ( parseDerivation
                                                 , buildDerivation
                                                 )
@@ -23,10 +24,10 @@ processDerivation source dest = do
     (Data.Text.IO.writeFile dest
       . toText
       . Data.Text.Lazy.Builder.toLazyText
-      . buildDerivation
+      . buildDerivation (StoreDir "/nix/store")
     )
     (Data.Attoparsec.Text.parseOnly
-      (parseDerivation "/nix/store")
+      (parseDerivation $ StoreDir "/nix/store")
       contents
     )
 

--- a/hnix-store-core/tests/StorePath.hs
+++ b/hnix-store-core/tests/StorePath.hs
@@ -1,5 +1,6 @@
 {-# language DataKinds           #-}
 {-# language ScopedTypeVariables #-}
+{-# language OverloadedStrings   #-}
 
 module StorePath where
 
@@ -11,19 +12,19 @@ import           System.Nix.StorePath
 import           Arbitrary
 
 -- | Test that Nix(OS) like paths roundtrip
-prop_storePathRoundtrip :: NixLike -> NixLike -> Property
-prop_storePathRoundtrip (_ :: NixLike) (NixLike x) =
-  parsePath "/nix/store" (storePathToRawFilePath x) === pure x
+prop_storePathRoundtrip :: StoreDir -> NixLike -> NixLike -> Property
+prop_storePathRoundtrip storeDir (_ :: NixLike) (NixLike x) =
+  parsePath storeDir (storePathToRawFilePath storeDir x) === pure x
 
 -- | Test that any `StorePath` roundtrips
-prop_storePathRoundtrip' :: StorePath -> Property
-prop_storePathRoundtrip' x =
-  parsePath (storePathRoot x) (storePathToRawFilePath x) === pure x
+prop_storePathRoundtrip' :: StoreDir -> StorePath -> Property
+prop_storePathRoundtrip' storeDir x =
+  parsePath storeDir (storePathToRawFilePath storeDir x) === pure x
 
-prop_storePathRoundtripParser :: NixLike -> NixLike -> Property
-prop_storePathRoundtripParser (_ :: NixLike) (NixLike x) =
-  Data.Attoparsec.Text.parseOnly (pathParser $ storePathRoot x) (storePathToText x) === pure x
+prop_storePathRoundtripParser :: StoreDir -> NixLike -> NixLike -> Property
+prop_storePathRoundtripParser storeDir (_ :: NixLike) (NixLike x) =
+  Data.Attoparsec.Text.parseOnly (pathParser storeDir) (storePathToText storeDir x) === pure x
 
-prop_storePathRoundtripParser' :: StorePath -> Property
-prop_storePathRoundtripParser' x =
-  Data.Attoparsec.Text.parseOnly (pathParser $ storePathRoot x) (storePathToText x) === pure x
+prop_storePathRoundtripParser' :: StoreDir -> StorePath -> Property
+prop_storePathRoundtripParser' storeDir x =
+  Data.Attoparsec.Text.parseOnly (pathParser storeDir) (storePathToText storeDir x) === pure x

--- a/hnix-store-remote/ChangeLog.md
+++ b/hnix-store-remote/ChangeLog.md
@@ -1,5 +1,13 @@
 # Revision history for hnix-store-remote
 
+## Unreleased 202y-mm-dd
+
+* Breaking:
+    * [(link)](https://github.com/haskell-nix/hnix-store/pull/216) `StorePath` no longer carries `storePathRoot` field and we
+      have a stand-alone `StoreDir` type instead to be used instead of `FilePath`
+      when store root directory is needed as a context.
+      Fore `-remote`, this affects `runStoreOpts` and its variants.
+
 ## [0.6.0.0](https://github.com/haskell-nix/hnix-store/compare/remote-0.5.0.0...remote-0.6.0.0) 2021-06-06
 
 * Breaking:

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -53,6 +53,7 @@ library
     , mtl
     , unordered-containers
     , hnix-store-core >= 0.6 && <0.7
+    , transformers
   mixins:
       base hiding (Prelude)
     , relude (Relude as Prelude)
@@ -98,6 +99,7 @@ test-suite hnix-store-remote-tests
     tasty-discover:tasty-discover
   build-depends:
       base
+    , bytestring
     , relude
     , hnix-store-core >= 0.3
     , hnix-store-remote


### PR DESCRIPTION
I disagree with myself in https://github.com/haskell-nix/hnix-store/issues/62 (maybe I was confused on real vs virtual store dir, or maybe I was just being stupid!)

I agree with https://github.com/haskell-nix/hnix-store/issues/148 too, which is an issue to undo it.

As a first step, I present this, which merely make `StorePath` not store the store dir, with any type-level stuff TBD. Yes, this is not ideal, but I think it's a good start. It is how C++ Nix and TVix do it these day. It is essentially never safe to mix up store paths with different store dirs, and so this is an improvement under the "make illegal states unrepresentative front".

Some of the daemon code got uglier, but I have a WIP big overhaul of that I'd hope to finish up at some point. That undoes the slight nuisance of these "get store dirs" that crop up everywhere with this PR.