### PR TITLE
Fix NAR parsing failure when not enough input is available

### DIFF
--- a/hnix-store-core/src/System/Nix/Internal/Nar/Parser.hs
+++ b/hnix-store-core/src/System/Nix/Internal/Nar/Parser.hs
@@ -421,7 +421,7 @@ consume
 consume 0 = pure ""
 consume n = do
   state0   <- State.get
-  newBytes <- IO.liftIO $ Bytes.hGetSome (handle state0) (max 0 n)
+  newBytes <- IO.liftIO $ Bytes.hGet (handle state0) (max 0 n)
   when (Bytes.length newBytes < n) $
     Fail.fail $
     "consume: Not enough bytes in handle. Wanted "


### PR DESCRIPTION
Replaces `hGetSome` with `hGet`, which should continue reading until the requested number of bytes have been read in. This avoids a potential failure mode where the requested bytes are not immediately available/buffered.

Resolves #225.