### PR TITLE
remote: build README.md via cabal

### DIFF
--- a/hnix-store-remote/README.lhs
+++ b/hnix-store-remote/README.lhs
@@ -1,0 +1,1 @@
+README.md

--- a/hnix-store-remote/README.md
+++ b/hnix-store-remote/README.md
@@ -12,17 +12,19 @@ via `nix-daemon`.
 ## Example
 
 ```haskell
+{-# LANGUAGE OverloadedStrings #-}
 
+import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
-import Data.HashSet as HS
 import System.Nix.Store.Remote
 
+main :: IO ()
 main = do
-  runStore $ do
+  void $ runStore $ do
     syncWithGC
     roots <- findRoots
     liftIO $ print roots
 
-    res <- addTextToStore "hnix-store" "test" (HS.fromList []) False
+    res <- addTextToStore "hnix-store" "test" mempty False
     liftIO $ print res
 ```

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -26,6 +26,12 @@ flag io-testsuite
     Enable testsuite, which requires external
     binaries and Linux namespace support.
 
+flag build-readme
+  default:
+    True
+  description:
+    Build README.lhs example
+
 library
   import: commons
   exposed-modules:
@@ -80,6 +86,16 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
+
+executable remote-readme
+  build-depends:
+      base >=4.12 && <5
+    , hnix-store-remote
+  build-tool-depends:
+      markdown-unlit:markdown-unlit
+  default-language: Haskell2010
+  main-is: README.lhs
+  ghc-options: -pgmL markdown-unlit -Wall
 
 test-suite hnix-store-remote-tests
   import: commons


### PR DESCRIPTION
Added as `remote-readme` executable.

Closes #47.