### PR TITLE
update test targets in hie.yaml

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -10,4 +10,7 @@ cradle:
       component: "lib:hnix-store-remote"
 
     - path: "./hnix-store-remote/tests"
-      component: "hnix-store-remote:test:hnix-store-remote-tests"
+      component: "hnix-store-remote:test:remote"
+
+    - path: "./hnix-store-remote/tests-io"
+      component: "hnix-store-remote:test:remote-io"


### PR DESCRIPTION
Update hie.yaml for the test target renames in b98fb44d7.

This allows me to use haskell-language-server with the test targets. Previously I got errors like this:

```
 Diagnostics:
 1. Failed to run ["cabal","v2-repl","hnix-store-remote:test:hnix-store-remote-tests"] in directory "/mnt/cherry/src/hnix-store". Consult the logs for full command and error.
    Failed command: cabal --builddir=/home/xx/.cache/hie-bios/dist-hnix-store-d7270ed6debafcfcfc3faeaa441212b9 v2-repl --with-compiler /home/xx/.cache/hie-bios/wrapper-b54f81dea4c0e6d1626911c526bc4e36 --with-hc-pkg /home/xx/.cache/hie-bios/ghc-pkg-eb84fa8498c7b90f206f13c233c2aabe hni 
 x-store-remote:test:hnix-store-remote-tests
    
    Error: cabal: Unknown target 'hnix-store-remote:test:hnix-store-remote-tests'.
    The package hnix-store-remote has no test-suite component
    'hnix-store-remote-tests'.
    Perhaps you meant the test-suite component 'lib:hnix-store-remote'?
    
    
    
    
    Process Environment:
    HIE_BIOS_GHC: /nix/store/psds2pz1qhlr4z8qcahqii6kq1xsawb8-ghc-9.4.8/lib/ghc-9.4.8/bin/ghc
    HIE_BIOS_GHC_ARGS: -B/nix/store/yy2fb5dxrwh97liidwr31w5hhqw2svah-ghc-9.4.8-with-packages/lib/ghc-9.4.8
```