### PR TITLE
remote: fix queryPathInfoUncached narHash decoding

### DIFF
--- a/hnix-store-remote/src/System/Nix/Store/Remote.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote.hs
@@ -46,7 +46,7 @@ import           System.Nix.Build               ( BuildMode
                                                 , BuildResult
                                                 )
 import           System.Nix.Hash                ( NamedAlgo(..)
-                                                , BaseEncoding(NixBase32)
+                                                , BaseEncoding(Base16)
                                                 , decodeDigestWith
                                                 )
 import           System.Nix.StorePath           ( StorePath
@@ -235,7 +235,7 @@ queryPathInfoUncached path = do
   let
     narHash =
       case
-        decodeDigestWith @SHA256 NixBase32 narHashText
+        decodeDigestWith @SHA256 Base16 narHashText
         of
         Left  e -> error e
         Right d -> System.Nix.Hash.HashAlgo_SHA256 :=> d

--- a/hnix-store-remote/tests-io/NixDaemon.hs
+++ b/hnix-store-remote/tests-io/NixDaemon.hs
@@ -33,6 +33,7 @@ import           System.FilePath
 
 import           System.Nix.Build
 import           System.Nix.StorePath
+import           System.Nix.StorePath.Metadata
 import           System.Nix.Store.Remote
 import           System.Nix.Store.Remote.Protocol
 
@@ -217,7 +218,9 @@ spec_protocol = Hspec.around withNixDaemon $
         queryAllValidPaths `shouldReturn` HS.fromList [path]
 
     context "queryPathInfoUncached" $
-      itRights "queries path info" $ withPath queryPathInfoUncached
+      itRights "queries path info" $ withPath $ \path -> do
+        meta <- queryPathInfoUncached path
+        references meta `shouldSatisfy` HS.null
 
     context "ensurePath" $
       itRights "simple ensure" $ withPath ensurePath


### PR DESCRIPTION
nix-daemon encodes the narHash as Base16, not NixBase32: https://github.com/NixOS/nix/blob/a6b315ae/src/libstore/worker-protocol.cc#L180

Change the narHash decoding step to use Base16.

Add a test that fails on the previous code with the following error:

    uncaught exception: ErrorCall
    Invalid NixBase32 string
    CallStack (from HasCallStack):

Tested with nix 2.13.6.