### PR TITLE
remote: fix queryPathInfoUncached missing content address decoding

### DIFF
--- a/hnix-store-remote/src/System/Nix/Store/Remote.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote.hs
@@ -34,6 +34,7 @@ import Data.Dependent.Sum (DSum((:=>)))
 import Data.HashSet (HashSet)
 import Data.Map (Map)
 import Data.Text (Text)
+import qualified Data.Text
 import qualified Control.Monad
 import qualified Data.Attoparsec.Text
 import qualified Data.Text.Encoding
@@ -253,6 +254,7 @@ queryPathInfoUncached path = do
       sigs = Data.Set.empty
 
       contentAddress =
+        if Data.Text.null caString then Nothing else
         case
           Data.Attoparsec.Text.parseOnly
             System.Nix.ContentAddress.contentAddressParser


### PR DESCRIPTION
queryPathInfoUncached fails with a "not enough input" message when decoding Metadata that is missing a content address.

nix-daemon encodes a missing content address as an empty string: https://github.com/NixOS/nix/blob/a6b315ae8/src/libstore/content-address.cc#L139

Change the decoding to return Nothing if the caString is empty.

I manually tested this with the following program:

```haskell
{-# LANGUAGE OverloadedStrings #-}

module Main

where

import System.Nix.Store.Remote
import System.Nix.StorePath
import Control.Monad (void)
import Control.Monad.IO.Class (liftIO)
import Data.Default.Class

main :: IO()
main = do
  void $ runStore $ do
    let Right sp = parsePath def "/nix/store/sbldylj3clbkc0aqvjjzfa6slp4zdvlj-hello-2.12.1"
    q <- queryPathInfoUncached sp
    liftIO $ print q
```
The store path came from `nix build nixpkgs#hello`. Tested with nix 2.13.6.