### PR TITLE
ci: disable haddock step

### DIFF
--- a/.github/workflows/ci.dhall
+++ b/.github/workflows/ci.dhall
@@ -6,6 +6,7 @@ let defSteps = haskellCi.defaultCabalSteps
 in    haskellCi.generalCi
         ( haskellCi.withNix
             ( defSteps
+              with docStep = None haskellCi.BuildStep
               with extraSteps.pre
                    =
                     defSteps.extraSteps.pre

--- a/.github/workflows/ci.dhall.frozen
+++ b/.github/workflows/ci.dhall.frozen
@@ -7,6 +7,7 @@ let defSteps = haskellCi.defaultCabalSteps
 in    haskellCi.generalCi
         ( haskellCi.withNix
             ( defSteps
+              with docStep = None haskellCi.BuildStep
               with extraSteps.pre
                    =
                     defSteps.extraSteps.pre

--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -7,6 +7,8 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 which dhall || cabal install dhall
 which dhall-to-yaml || cabal install dhall-yaml
 
+echo "dhall format-ing ci.dhall"
+dhall format ci.dhall
 echo "cp haskellCi.dhall -> ci.dhall.frozen"
 cp ci.dhall ci.dhall.frozen
 echo "dhall freez-ing ci.dhall.frozen"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,8 +40,6 @@ jobs:
       run: "cabal build all --enable-tests --enable-benchmarks"
     - name: test all
       run: "cabal test all --enable-tests"
-    - name: haddock all
-      run: cabal haddock all
     - name: Build with Nix
       run: "nix-build --argstr compiler $(echo ghc${{ matrix.ghc }} | tr -d '.')"
     strategy:


### PR DESCRIPTION
takes too long and it runs in `nix-build` anyway.

Ideally we would do `cabal haddock-project` but that is not yet available everywhere (due to older haddock).

Maybe revisit later.