### PR TITLE
remote: add NarFromPath client

### DIFF
--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -196,7 +196,8 @@ test-suite remote-io
   -- See https://github.com/redneb/hs-linux-namespaces/issues/3
   ghc-options:       -rtsopts -fprof-auto "-with-rtsopts -V0"
   other-modules:
-      NixDaemonSpec
+      DataSink
+    , NixDaemonSpec
     , SampleNar
   build-depends:
       base >=4.12 && <5

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
@@ -106,6 +106,7 @@ instance Arbitrary (Some StoreRequest) where
     , Some . EnsurePath <$> arbitrary
     , pure $ Some FindRoots
     , Some . IsValidPath <$> arbitrary
+    , Some . NarFromPath <$> arbitrary
     , Some <$> (QueryValidPaths <$> arbitrary <*> arbitrary)
     , pure $ Some QueryAllValidPaths
     , Some . QuerySubstitutablePaths <$> arbitrary

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Client.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Client.hs
@@ -11,6 +11,7 @@ module System.Nix.Store.Remote.Client
   , ensurePath
   , findRoots
   , isValidPath
+  , narFromPath
   , queryValidPaths
   , queryAllValidPaths
   , querySubstitutablePaths
@@ -180,6 +181,18 @@ isValidPath
   => StorePath
   -> m Bool
 isValidPath = doReq . IsValidPath
+
+-- | Download a NAR file.
+narFromPath
+  :: MonadRemoteStore m
+  => StorePath -- ^ Path to generate a NAR for
+  -> Word64 -- ^ Byte length of NAR
+  -> (ByteString -> IO()) -- ^ Data sink where NAR bytes will be written
+  -> m ()
+narFromPath path narSize sink = do
+  setDataSink sink
+  setDataSinkSize narSize
+  void $ doReq (NarFromPath path)
 
 -- | Query valid paths from a set,
 -- optionally try to use substitutes

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
@@ -1135,6 +1135,9 @@ storeRequest = Serializer
       WorkerOp_IsValidPath -> mapGetE $ do
         Some . IsValidPath <$> getS storePath
 
+      WorkerOp_NarFromPath -> mapGetE $ do
+        Some . NarFromPath <$> getS storePath
+
       WorkerOp_QueryValidPaths -> mapGetE $ do
         paths <- getS (hashSet storePath)
         substituteMode <- getS enum
@@ -1191,7 +1194,6 @@ storeRequest = Serializer
       w@WorkerOp_ExportPath -> notYet w
       w@WorkerOp_HasSubstitutes -> notYet w
       w@WorkerOp_ImportPaths -> notYet w
-      w@WorkerOp_NarFromPath -> notYet w
       w@WorkerOp_QueryDerivationOutputMap -> notYet w
       w@WorkerOp_QueryDeriver -> notYet w
       w@WorkerOp_QueryFailedPaths -> notYet w
@@ -1278,6 +1280,10 @@ storeRequest = Serializer
 
       Some (IsValidPath path) -> mapPutE $ do
         putS workerOp WorkerOp_IsValidPath
+        putS storePath path
+
+      Some (NarFromPath path) -> mapPutE $ do
+        putS workerOp WorkerOp_NarFromPath
         putS storePath path
 
       Some (QueryValidPaths paths substituteMode) -> mapPutE $ do

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Server.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Server.hs
@@ -181,6 +181,7 @@ processConnection workerHelper postGreet sock = do
             r@EnsurePath {} -> perform r
             r@FindRoots {} -> perform r
             r@IsValidPath {} -> perform r
+            r@NarFromPath {} -> perform r
             r@QueryValidPaths {} -> perform r
             r@QueryAllValidPaths {} -> perform r
             r@QuerySubstitutablePaths {} -> perform r

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/StoreRequest.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/StoreRequest.hs
@@ -104,6 +104,11 @@ data StoreRequest :: Type -> Type where
     :: StorePath
     -> StoreRequest Bool
 
+  -- | Fetch a NAR from the server
+  NarFromPath
+    :: StorePath
+    -> StoreRequest NoReply
+
   -- | Query valid paths from set, optionally try to use substitutes.
   QueryValidPaths
     :: HashSet StorePath
@@ -179,6 +184,7 @@ instance {-# OVERLAPPING #-} Eq (Some StoreRequest) where
   Some (EnsurePath a) == Some (EnsurePath a') = a == a'
   Some (FindRoots) == Some (FindRoots) = True
   Some (IsValidPath a) == Some (IsValidPath a') = a == a'
+  Some (NarFromPath a) == Some (NarFromPath a') = a == a'
   Some (QueryValidPaths a b) == Some (QueryValidPaths a' b') = (a, b) == (a', b')
   Some QueryAllValidPaths == Some QueryAllValidPaths = True
   Some (QuerySubstitutablePaths a) == Some (QuerySubstitutablePaths a') = a == a'

--- a/hnix-store-remote/tests-io/DataSink.hs
+++ b/hnix-store-remote/tests-io/DataSink.hs
@@ -1,0 +1,26 @@
+module DataSink
+
+( DataSink(..)
+, dataSinkResult
+, dataSinkWriter
+, newDataSink
+)
+
+where
+
+import Data.ByteString (ByteString)
+
+import Control.Monad.ST
+import Data.STRef
+
+-- | Basic data sink for testing
+newtype DataSink = DataSink (STRef RealWorld ByteString)
+
+newDataSink :: IO DataSink
+newDataSink = DataSink <$> (stToIO . newSTRef) mempty
+
+dataSinkWriter :: DataSink -> (ByteString -> IO())
+dataSinkWriter (DataSink stref) chunk = stToIO (modifySTRef stref (chunk <>))
+
+dataSinkResult :: DataSink -> IO ByteString
+dataSinkResult (DataSink stref) = (stToIO . readSTRef) stref

--- a/hnix-store-remote/tests-io/SampleNar.hs
+++ b/hnix-store-remote/tests-io/SampleNar.hs
@@ -6,6 +6,7 @@ module SampleNar
 ( SampleNar(..)
 , buildDataSource
 , sampleNar0
+, encodeNar
 )
 
 where
@@ -39,7 +40,7 @@ data SampleNar
 sampleNar0 :: IO SampleNar
 sampleNar0 = do
   let sampleNar_fileData = "hello"
-  sampleNar_narData <- bytesToNar sampleNar_fileData
+  sampleNar_narData <- encodeNar sampleNar_fileData
   let sampleNar_metadata = Metadata
         { metadataDeriverPath = Just $ forceParsePath "/nix/store/g2mxdrkwr1hck4y5479dww7m56d1x81v-hello-2.12.1.drv"
         , metadataNarHash = sha256 sampleNar_narData
@@ -78,8 +79,8 @@ forceParsePath path = case parsePath def path of
 sha256 :: ByteString -> DSum HashAlgo Digest
 sha256 bs = HashAlgo_SHA256 :=> hashFinalize (hashUpdate (hashInit @SHA256) bs)
 
-bytesToNar :: ByteString -> IO ByteString
-bytesToNar bytes = do
+encodeNar :: ByteString -> IO ByteString
+encodeNar bytes = do
   ref <- stToIO $ newSTRef mempty
   let accumFn chunk = do
        stToIO $ modifySTRef ref (<> chunk)


### PR DESCRIPTION
Adds a client for the NarFromPath operation along with a small test.

The NAR size is not provided by the server. The user needs to provide it to the NarFromPath call. It determines how many bytes get read from the server. If the client provides the wrong byte size, the call will fail in a bad way, like hanging open. I don't think there's any way to avoid this.

The size isn't part of the wire protocol so it can't go in the StoreRequest type (roundtrip tests wouldn't work). I elected to put it in RemoteStoreState alongside the sink. This seems unpleasant. There might be a better way to arrange this.

Closes #266