### PR TITLE
nar: fix executable permissions logic

### DIFF
--- a/hnix-store-nar/hnix-store-nar.cabal
+++ b/hnix-store-nar/hnix-store-nar.cabal
@@ -96,6 +96,7 @@ test-suite nar
     tasty-discover:tasty-discover
   build-depends:
       base
+    , cryptonite
     , hnix-store-nar
     , base64-bytestring
     , cereal

--- a/hnix-store-nar/src/System/Nix/Nar/Effects.hs
+++ b/hnix-store-nar/src/System/Nix/Nar/Effects.hs
@@ -123,12 +123,20 @@ streamStringOutIO f executable getChunk =
       "Failed to stream string to " <> f <> ": " <> show e
 
 -- | Check whether the file is executable by the owner.
+--
+--   Matches the logic used by Nix.
+--
+--   access() should not be used for this purpose on macOS.
+--   It returns false for executables when placed in certain directories.
+--   For example, when in an app bundle: App.app/Contents/Resources/en.lproj/myexecutable.strings
 isExecutable :: FileStatus -> Bool
 isExecutable st =
   isRegularFile st
     && fileMode st `intersectFileModes` ownerExecuteMode /= nullFileMode
 
 -- | Set the file to be executable by the owner, group, and others.
+--
+--   Matches the logic used by Nix.
 setExecutable :: FilePath -> IO ()
 setExecutable f = do
   st <- getSymbolicLinkStatus f

--- a/hnix-store-nar/tests/NarFormat.hs
+++ b/hnix-store-nar/tests/NarFormat.hs
@@ -145,6 +145,8 @@ unit_nixStoreDirectory' :: HU.Assertion
 unit_nixStoreDirectory' = filesystemNixStore "directory'" (Nar sampleDirectory')
 
 -- | Test that the executable permissions are handled correctly in app bundles on macOS.
+--   In this case, access() returns false for a file under this specific path, even when the executable bit is set.
+--   NAR implementations should avoid this syscall on macOS.
 test_nixStoreMacOSAppBundle :: TestTree
 test_nixStoreMacOSAppBundle = packThenExtract "App.app" $ \ baseDir -> do
   let testDir = baseDir </> "App.app" </> "Resources" </> "en.lproj"


### PR DESCRIPTION
This PR replaces `Directories.getPermissions`, which uses `access` to test whether the file is executable, with a mix of functions from the `unix` package to replicate the logic that Nix uses.

Nix doesn't use `access` to check whether a file is executable. It instead checks whether the owner executable bit is set.

When unpacking a NAR, Nix sets the executable bits for the owner, group, and other.

Fixes https://github.com/cachix/cachix/issues/664.

#### Example in the wild

In the linked issue, the build of IINA contains multiple files with the extension `.strings` and permissions `.r-xr-xr-x`. Take for  example, `result/Applications/IINA.app/Contents/Resources/de.lproj/AboutWindowController.strings`.
`access` returns false for `X_OK` when run on this file.
hnix fails to mark these files as executable when generating the NAR.