### PR TITLE
Release `core 0.8`, remote `0.7` and new packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hnix-store
 
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/haskell-nix/hnix-store/ci.yaml?branch=master)](https://github.com/haskell-nix/hnix-store/actions/workflows/ci.yaml)
+
 A Haskell interface to the [Nix] store.
 
 [Nix]: https://nixos.org/nix
@@ -44,12 +46,11 @@ several Haskell packages.
 
 ### [hnix-store-core]
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/haskell-nix/hnix-store/ci.yaml?branch=master)](https://github.com/haskell-nix/hnix-store/actions/workflows/ci.yaml)
 [![Hackage version](https://img.shields.io/hackage/v/hnix-store-core.svg?color=success)](https://hackage.haskell.org/package/hnix-store-core)
 [![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-core?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-core)
 
-Contains the core effect types and
-fundamental operations combining them, agnostic to any particular
+Contains the core types and
+fundamental operations, agnostic to any particular
 effectful implementation (e.g. in-memory, talking to the Nix daemon in
 IO, etc.), with the actual implementations in a different package.
 
@@ -58,14 +59,53 @@ interact with the `Nix` store can simply depend on `hnix-store-core`,
 and only at the very edges of the system would it be necessary to
 bring in a specific implementation.
 
+### [hnix-store-db]
+
+[![Hackage version](https://img.shields.io/hackage/v/hnix-store-db.svg?color=success)](https://hackage.haskell.org/package/hnix-store-db)
+[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-db?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-db)
+
+Implementation of the `Nix` store SQLite database.
+
+### [hnix-store-json]
+
+[![Hackage version](https://img.shields.io/hackage/v/hnix-store-json.svg?color=success)](https://hackage.haskell.org/package/hnix-store-json)
+[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-json?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-json)
+
+`Aeson` instances for core types, required for remote store protocol.
+
+### [hnix-store-nar]
+
+[![Hackage version](https://img.shields.io/hackage/v/hnix-store-nar.svg?color=success)](https://hackage.haskell.org/package/hnix-store-nar)
+[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-nar?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-nar)
+
+Packing and unpacking for NAR file format used by Nix.
+
+### [hnix-store-readonly]
+
+[![Hackage version](https://img.shields.io/hackage/v/hnix-store-readonly.svg?color=success)](https://hackage.haskell.org/package/hnix-store-readonly)
+[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-readonly?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-readonly)
+
+Path computation without interaction with the actual `Nix` store
+
 ### [hnix-store-remote]
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/haskell-nix/hnix-store/ci.yaml?branch=master)](https://github.com/haskell-nix/hnix-store/actions/workflows/ci.yaml)
 [![Hackage version](https://img.shields.io/hackage/v/hnix-store-remote.svg?color=success)](https://hackage.haskell.org/package/hnix-store-remote)
 [![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-remote?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-remote)
 
 [Nix] worker protocol implementation for interacting with remote Nix store
 via `nix-daemon`.
 
+### [hnix-store-tests]
+
+[![Hackage version](https://img.shields.io/hackage/v/hnix-store-tests.svg?color=success)](https://hackage.haskell.org/package/hnix-store-tests)
+[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-tests?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-tests)
+
+Aribtrary instances and utilities for testing.
+
 [hnix-store-core]: ./hnix-store-core
+[hnix-store-db]: ./hnix-store-db
+[hnix-store-json]: ./hnix-store-json
+[hnix-store-nar]: ./hnix-store-nar
+[hnix-store-readonly]: ./hnix-store-readonly
 [hnix-store-remote]: ./hnix-store-remote
+[hnix-store-tests]: ./hnix-store-tests

--- a/hnix-store-core/CHANGELOG.md
+++ b/hnix-store-core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# [0.8.0.0](https://github.com/haskell-nix/hnix-store/compare/core-0.7.0.0...core-0.8.0.0) 2024-07-31
 
 * Changes:
    * `System.Nix.StorePath.makeStorePathName` renamed to `System.Nix.StorePath.mkStorePathName`
@@ -6,7 +6,7 @@
      and renamed to `System.Nix.Store.ReadOnly` [#247](https://github.com/haskell-nix/hnix-store/pull/247)
    * `System.Nix.Nar*` moved to `hnix-store-nar` package [#247](https://github.com/haskell-nix/hnix-store/pull/247)
    * `Arbitrary` instances moved to `hnix-store-tests` package [#241](https://github.com/haskell-nix/hnix-store/pull/241)
-   * `System.Nix.Internal` namespaces was removed [#236](https://github.com/haskell-nix/hnix-store/pull/236)
+   * `System.Nix.Internal` namespace was removed [#236](https://github.com/haskell-nix/hnix-store/pull/236)
    * `StorePathMetadata` converted to `Metadata a` [#231](https://github.com/haskell-nix/hnix-store/pull/231)
      * Moved to `System.Nix.StorePath.Metadata` [#236](https://github.com/haskell-nix/hnix-store/pull/236)
    * Constructors of `StorePathName` and `StorePathHashPart` are no longer
@@ -159,3 +159,9 @@ exist and we can tell what common effects they should share.
 # 0.1.0.0  -- 2019-03-18
 
 * First version.
+
+---
+
+`hnix-store-core` uses [PVP Versioning][1].
+
+[1]: https://pvp.haskell.org

--- a/hnix-store-core/hnix-store-core.cabal
+++ b/hnix-store-core/hnix-store-core.cabal
@@ -13,9 +13,10 @@ maintainer:          srk@48.io
 copyright:           2018 Shea Levy
 category:            Nix
 build-type:          Simple
-extra-source-files:
+extra-doc-files:
     CHANGELOG.md
-  , README.md
+extra-source-files:
+    README.md
   , tests/samples/example0.drv
   , tests/samples/example1.drv
 

--- a/hnix-store-db/CHANGELOG.md
+++ b/hnix-store-db/CHANGELOG.md
@@ -1,3 +1,9 @@
-# Unreleased 202y-mm-dd
+# 0.1.0.0 2024-07-31
 
-* First version.
+* Initial release
+
+---
+
+`hnix-store-db` uses [PVP Versioning][1].
+
+[1]: https://pvp.haskell.org

--- a/hnix-store-db/hnix-store-db.cabal
+++ b/hnix-store-db/hnix-store-db.cabal
@@ -6,9 +6,9 @@ description:         Implementation of the nix store database
 homepage:            https://github.com/haskell-nix/hnix-store
 license:             Apache-2.0
 license-file:        LICENSE
-author:              Richard Marko
+author:              Sorki
 maintainer:          srk@48.io
-copyright:           2023 Richard Marko
+copyright:           2023 Sorki
 category:            Nix
 build-type:          Simple
 extra-source-files:

--- a/hnix-store-db/hnix-store-db.cabal
+++ b/hnix-store-db/hnix-store-db.cabal
@@ -11,9 +11,10 @@ maintainer:          srk@48.io
 copyright:           2023 Sorki
 category:            Nix
 build-type:          Simple
-extra-source-files:
+extra-doc-files:
     CHANGELOG.md
-  , README.md
+extra-source-files:
+    README.md
   , README.lhs
 
 flag build-bench

--- a/hnix-store-db/hnix-store-db.cabal
+++ b/hnix-store-db/hnix-store-db.cabal
@@ -2,7 +2,7 @@ cabal-version:       2.2
 name:                hnix-store-db
 version:             0.1.0.0
 synopsis:            Nix store database support
-description:         Implementation of the nix store database
+description:         Implementation of the Nix store database
 homepage:            https://github.com/haskell-nix/hnix-store
 license:             Apache-2.0
 license-file:        LICENSE

--- a/hnix-store-json/CHANGELOG.md
+++ b/hnix-store-json/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version [0.1.0.0](https://github.com/haskell-nix/hnix-store/compare/json-0.1.0.0...json-0.1.1.0) (2023-11-27)
+# 0.1.0.0 2024-07-31
 
 * Initial release
 
@@ -7,4 +7,3 @@
 `hnix-store-json` uses [PVP Versioning][1].
 
 [1]: https://pvp.haskell.org
-

--- a/hnix-store-json/hnix-store-json.cabal
+++ b/hnix-store-json/hnix-store-json.cabal
@@ -7,9 +7,9 @@ description:
 homepage:            https://github.com/haskell-nix/hnix-store
 license:             Apache-2.0
 license-file:        LICENSE
-author:              Richard Marko
+author:              Sorki
 maintainer:          srk@48.io
-copyright:           2023 Richard Marko
+copyright:           2023 Sorki
 category:            Nix
 build-type:          Simple
 extra-source-files:

--- a/hnix-store-json/hnix-store-json.cabal
+++ b/hnix-store-json/hnix-store-json.cabal
@@ -3,7 +3,7 @@ name:                hnix-store-json
 version:             0.1.0.0
 synopsis:            JSON serialization for core types
 description:
-  Aeson instances for core types
+  Aeson instances for core types, required for remote store protocol
 homepage:            https://github.com/haskell-nix/hnix-store
 license:             Apache-2.0
 license-file:        LICENSE

--- a/hnix-store-json/hnix-store-json.cabal
+++ b/hnix-store-json/hnix-store-json.cabal
@@ -12,9 +12,10 @@ maintainer:          srk@48.io
 copyright:           2023 Sorki
 category:            Nix
 build-type:          Simple
-extra-source-files:
+extra-doc-files:
     CHANGELOG.md
-  , README.md
+extra-source-files:
+    README.md
 
 common commons
   ghc-options:  -Wall

--- a/hnix-store-nar/CHANGELOG.md
+++ b/hnix-store-nar/CHANGELOG.md
@@ -1,10 +1,9 @@
-# Version [0.1.0.0](https://github.com/haskell-nix/hnix-store/compare/nar-0.1.0.0...nar-0.1.1.0) (2023-11-27)
+# 0.1.0.0 2024-07-31
 
-* Initial release
+* Initial release after a split from `hnix-store-core`
 
 ---
 
 `hnix-store-nar` uses [PVP Versioning][1].
 
 [1]: https://pvp.haskell.org
-

--- a/hnix-store-nar/hnix-store-nar.cabal
+++ b/hnix-store-nar/hnix-store-nar.cabal
@@ -21,6 +21,7 @@ extra-source-files:
 flag bounded_memory
   description: Run tests of constant memory use (requires +RTS -T)
   default: False
+  manual: True
 
 common commons
   ghc-options:  -Wall

--- a/hnix-store-nar/hnix-store-nar.cabal
+++ b/hnix-store-nar/hnix-store-nar.cabal
@@ -12,9 +12,10 @@ maintainer:          srk@48.io
 copyright:           2018 Shea Levy
 category:            Nix
 build-type:          Simple
-extra-source-files:
+extra-doc-files:
     CHANGELOG.md
-  , README.md
+extra-source-files:
+    README.md
   , tests/fixtures/case-conflict.nar
 
 flag bounded_memory

--- a/hnix-store-readonly/CHANGELOG.md
+++ b/hnix-store-readonly/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version [0.1.0.0](https://github.com/haskell-nix/hnix-store/compare/readonly-0.1.0.0...readonly-0.1.1.0) (2023-11-27)
+# 0.1.0.0 2024-07-31
 
 * Initial release
 
@@ -7,4 +7,3 @@
 `hnix-store-readonly` uses [PVP Versioning][1].
 
 [1]: https://pvp.haskell.org
-

--- a/hnix-store-readonly/hnix-store-readonly.cabal
+++ b/hnix-store-readonly/hnix-store-readonly.cabal
@@ -12,9 +12,10 @@ maintainer:          srk@48.io
 copyright:           2018 Shea Levy
 category:            Nix
 build-type:          Simple
-extra-source-files:
+extra-doc-files:
     CHANGELOG.md
-  , README.md
+extra-source-files:
+    README.md
 
 common commons
   ghc-options:  -Wall

--- a/hnix-store-remote/CHANGELOG.md
+++ b/hnix-store-remote/CHANGELOG.md
@@ -63,3 +63,9 @@ Nothing (it is tandem `hnix-store-core` fix release)
 # 0.1.0.0  -- 2019-03-18
 
 * First version.
+
+---
+
+`hnix-store-remote` uses [PVP Versioning][1].
+
+[1]: https://pvp.haskell.org

--- a/hnix-store-remote/CHANGELOG.md
+++ b/hnix-store-remote/CHANGELOG.md
@@ -1,10 +1,21 @@
-# Unreleased 202y-mm-dd
+# [0.7.0.0](https://github.com/haskell-nix/hnix-store/compare/remote-0.6.0.0...remote-0.7.0.0) 2024-07-31
 
 * Changes:
     * `StorePath` no longer carries `storePathRoot` field and we
       have a stand-alone `StoreDir` type instead to be used instead of `FilePath`
       when store root directory is needed as a context.
       Fore `-remote`, this affects `runStoreOpts` and its variants [#216](https://github.com/haskell-nix/hnix-store/pull/216)
+    * The old `MonadStore` is now deprecated and aliased to `RemoteStoreT IO`
+    * All store operations now use `MonadRemoteStore` typeclass, which `RemoteStoreT` is an instance of
+    * Couple of `Bool` parameters switched to enums
+
+* Additions
+    * `addToStoreNAR` store operation [#277](https://github.com/haskell-nix/hnix-store/pull/277)
+    * `narFromPath` store operation [#279](https://github.com/haskell-nix/hnix-store/pull/279)
+    * Initial server-side support with proxy daemon acting as MITM proxy,
+      which allows for testing of both sides of the remote store protocol
+
+The library stability is not quite there yet and should be considered experimental.
 
 # [0.6.0.0](https://github.com/haskell-nix/hnix-store/compare/remote-0.5.0.0...remote-0.6.0.0) 2021-06-06
 

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -11,9 +11,10 @@ maintainer:          srk@48.io
 copyright:           2018 Sorki
 category:            Nix
 build-type:          Simple
-extra-source-files:
+extra-doc-files:
     CHANGELOG.md
-  , README.md
+extra-source-files:
+    README.md
   , README.lhs
 
 common commons

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -6,9 +6,9 @@ description:         Implementation of the nix store using the daemon protocol.
 homepage:            https://github.com/haskell-nix/hnix-store
 license:             Apache-2.0
 license-file:        LICENSE
-author:              Richard Marko
+author:              Sorki
 maintainer:          srk@48.io
-copyright:           2018 Richard Marko
+copyright:           2018 Sorki
 category:            Nix
 build-type:          Simple
 extra-source-files:

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                hnix-store-remote
-version:             0.6.0.0
+version:             0.7.0.0
 synopsis:            Remote hnix store
 description:         Implementation of the nix store using the daemon protocol.
 homepage:            https://github.com/haskell-nix/hnix-store

--- a/hnix-store-remote/src/Data/Serializer.hs
+++ b/hnix-store-remote/src/Data/Serializer.hs
@@ -3,7 +3,7 @@
 {-|
 Description : Serializer data type
 Copyright   : (c) John Ericson, 2023
-                  Richard Marko, 2023
+                  Sorki, 2023
 Stability   : experimental
 
 @Serializer@ ties @Get@ and @PutM@ monads

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
@@ -2,7 +2,7 @@
 {-|
 Description : NixSerializer
 Copyright   : (c) John Ericson, 2023
-                  Richard Marko, 2023
+                  Sorki, 2023
 |-}
 
 module System.Nix.Store.Remote.Serializer

--- a/hnix-store-tests/CHANGELOG.md
+++ b/hnix-store-tests/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version [0.1.0.0](https://github.com/haskell-nix/hnix-store/compare/tests-0.1.0.0...tests-0.1.1.0) (2023-11-27)
+# 0.1.0.0 2024-07-31
 
 * Initial release
 
@@ -7,4 +7,3 @@
 `hnix-store-tests` uses [PVP Versioning][1].
 
 [1]: https://pvp.haskell.org
-

--- a/hnix-store-tests/hnix-store-tests.cabal
+++ b/hnix-store-tests/hnix-store-tests.cabal
@@ -15,9 +15,10 @@ maintainer:          srk@48.io
 copyright:           2023 Sorki
 category:            Nix
 build-type:          Simple
-extra-source-files:
+extra-doc-files:
     CHANGELOG.md
-  , README.md
+extra-source-files:
+    README.md
 
 common commons
   ghc-options:  -Wall

--- a/hnix-store-tests/hnix-store-tests.cabal
+++ b/hnix-store-tests/hnix-store-tests.cabal
@@ -10,9 +10,9 @@ description:
 homepage:            https://github.com/haskell-nix/hnix-store
 license:             Apache-2.0
 license-file:        LICENSE
-author:              Richard Marko
+author:              Sorki
 maintainer:          srk@48.io
-copyright:           2023 Richard Marko
+copyright:           2023 Sorki
 category:            Nix
 build-type:          Simple
 extra-source-files:


### PR DESCRIPTION
including
- `hnix-store-db`
- `hnix-store-json`
- `hnix-store-nar`
- `hnix-store-readonly`
- `hnix-store-tests`

all starting at `0.1`