### PR TITLE
Support daemon protocol >= 1.37, drop older versions

### DIFF
--- a/hnix-store-core/src/System/Nix/ContentAddress.hs
+++ b/hnix-store-core/src/System/Nix/ContentAddress.hs
@@ -5,6 +5,8 @@ module System.Nix.ContentAddress (
   , methodToText
   , textToMethod
   , ContentAddressMethod (..)
+  , methodAlgoBuilder
+  , methodAlgoParser
   , contentAddressBuilder
   , contentAddressParser
   , buildContentAddress
@@ -17,6 +19,7 @@ import Crypto.Hash (Digest)
 import Data.Attoparsec.Text (Parser)
 import Data.Attoparsec.Text qualified
 import Data.Dependent.Sum (DSum)
+import Data.Some (Some(..))
 import Data.Text (Text)
 import Data.Text qualified
 import Data.Text.Lazy qualified
@@ -73,15 +76,35 @@ buildContentAddress =
   . Data.Text.Lazy.Builder.toLazyText
   . contentAddressBuilder
 
+-- | Render the method prefix used in content address strings.
+--
+-- @"text:"@, @"fixed:"@ (flat), @"fixed:r:"@ (nar)
+methodPrefix :: ContentAddressMethod -> Builder
+methodPrefix = \case
+  ContentAddressMethod_Text -> "text:"
+  ContentAddressMethod_Flat -> "fixed:"
+  ContentAddressMethod_NixArchive -> "fixed:r:"
+
+-- | Render method and hash algorithm, e.g. @"fixed:r:sha256"@.
+--
+-- Used in the daemon wire protocol for @AddToStore@ (>= 1.25).
+methodAlgoBuilder :: ContentAddressMethod -> Some HashAlgo -> Builder
+methodAlgoBuilder method (Some hashAlgo) =
+  methodPrefix method <> Data.Text.Lazy.Builder.fromText (System.Nix.Hash.algoToText hashAlgo)
+
+-- | Parse method and hash algorithm from wire format.
+methodAlgoParser :: Parser (ContentAddressMethod, Some HashAlgo)
+methodAlgoParser = do
+  method <- parseContentAddressMethod
+  _ <- ":"
+  hashAlgoText <- "sha256" <|> "sha512" <|> "sha1" <|> "md5"
+  case System.Nix.Hash.textToAlgo hashAlgoText of
+    Left e -> fail e
+    Right algo -> pure (method, algo)
+
 contentAddressBuilder :: ContentAddress -> Builder
 contentAddressBuilder (ContentAddress method digest) =
-  (case method of
-    ContentAddressMethod_Text -> "text"
-    ContentAddressMethod_NixArchive -> "fixed:r"
-    ContentAddressMethod_Flat -> "fixed"
-  )
-  <> ":"
-  <> System.Nix.Hash.algoDigestBuilder digest
+  methodPrefix method <> System.Nix.Hash.algoDigestBuilder digest
 
 -- | Parse `ContentAddressableAddress` from `ByteString`
 parseContentAddress

--- a/hnix-store-remote/CHANGELOG.md
+++ b/hnix-store-remote/CHANGELOG.md
@@ -8,6 +8,11 @@
    * Update `buildResult` serializer for new `BuildSuccess`/`BuildFailure` types
    * Update `buildTraceKeyTyped` serializer for `StorePath`-based `BuildTraceKey`
    * New dependency: `mmorph`
+   * Protocol version updated to 1.38
+   * `ProtoVersion` now includes `protoVersion_features :: Set Text` for feature negotiation
+   * Feature negotiation during handshake (client and server) when both sides >= 1.38
+   * `PartialOrd` replaces `Ord` on `ProtoVersion` (from `lattices`)
+   * New dependency: `lattices`
 
 # [0.7.0.0](https://github.com/haskell-nix/hnix-store/compare/remote-0.6.0.0...remote-0.7.0.0) 2024-07-31
 

--- a/hnix-store-remote/CHANGELOG.md
+++ b/hnix-store-remote/CHANGELOG.md
@@ -9,7 +9,7 @@
    * Update `buildTraceKeyTyped` serializer for `StorePath`-based `BuildTraceKey`
    * New dependency: `mmorph`
    * Protocol version updated to 1.38
-   * `ProtoVersion` now includes `protoVersion_features :: Set Text` for feature negotiation
+   * `ProtoVersion` now includes `protoVersion_features :: Set ProtoFeature` for feature negotiation
    * Feature negotiation during handshake (client and server) when both sides >= 1.38
    * `PartialOrd` replaces `Ord` on `ProtoVersion` (from `lattices`)
    * New dependency: `lattices`

--- a/hnix-store-remote/hnix-store-remote.cabal
+++ b/hnix-store-remote/hnix-store-remote.cabal
@@ -124,6 +124,7 @@ library
     , exceptions
     , generic-arbitrary < 1.1
     , hashable
+    , lattices
     , mmorph
     , text
     , time
@@ -182,6 +183,7 @@ test-suite remote
     , hnix-store-remote
     , hnix-store-tests
     , hnix-store-aterm
+    , containers
     , crypton
     , some > 1.0.5 && < 2
     , hspec

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
@@ -10,7 +10,7 @@ import System.Nix.StorePath (StorePath(..))
 import System.Nix.Store.Types (RepairMode(..))
 import System.Nix.Store.Remote.Types
 
-import Test.QuickCheck (Arbitrary(..), oneof, suchThat)
+import Test.QuickCheck (Arbitrary(..), arbitraryBoundedEnum, oneof, suchThat)
 import Test.QuickCheck.Arbitrary.Generic (GenericArbitrary(..))
 
 deriving via GenericArbitrary CheckMode
@@ -26,6 +26,9 @@ deriving via GenericArbitrary ProtoStoreConfig
 -- features are always empty (features are exchanged separately, not in wire format).
 instance Arbitrary ProtoVersion where
   arbitrary = ProtoVersion 1 <$> arbitrary <*> pure mempty
+
+instance Arbitrary ProtoFeature where
+  arbitrary = arbitraryBoundedEnum
 
 deriving via GenericArbitrary StoreText
   instance Arbitrary StoreText

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
@@ -22,8 +22,10 @@ deriving via GenericArbitrary SubstituteMode
 deriving via GenericArbitrary ProtoStoreConfig
   instance Arbitrary ProtoStoreConfig
 
-deriving via GenericArbitrary ProtoVersion
-  instance Arbitrary ProtoVersion
+-- Custom instance: major is always 1 (the only real protocol major version),
+-- features are always empty (features are exchanged separately, not in wire format).
+instance Arbitrary ProtoVersion where
+  arbitrary = ProtoVersion 1 <$> arbitrary <*> pure mempty
 
 deriving via GenericArbitrary StoreText
   instance Arbitrary StoreText
@@ -49,9 +51,6 @@ instance Arbitrary Trace where
     traceHint <- arbitrary
 
     pure Trace{..}
-
-deriving via GenericArbitrary BasicError
-  instance Arbitrary BasicError
 
 instance Arbitrary ErrorInfo where
   arbitrary = do
@@ -97,7 +96,7 @@ deriving via GenericArbitrary WorkerOp
 
 instance Arbitrary (Some StoreRequest) where
   arbitrary = oneof
-    [ Some <$> (AddToStore <$> arbitrary <*> arbitrary <*> arbitrary <*> pure RepairMode_DontRepair)
+    [ Some <$> (AddToStore <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary)
     , Some <$> (AddTextToStore <$> arbitrary <*> arbitrary <*> pure RepairMode_DontRepair)
     , Some <$> (AddSignatures <$> arbitrary <*> arbitrary)
     , Some . AddIndirectRoot  <$> arbitrary

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Client.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Client.hs
@@ -54,7 +54,7 @@ import System.Nix.Store.Remote.Types.StoreRequest (StoreRequest(..))
 import System.Nix.Store.Remote.Types.StoreText (StoreText)
 import System.Nix.Store.Remote.Types.SubstituteMode (SubstituteMode)
 import System.Nix.Store.Remote.Client.Core
-import System.Nix.FileContentAddress (FileIngestionMethod(..))
+import System.Nix.ContentAddress (ContentAddressMethod)
 import System.Nix.Store.Types (RepairMode(..))
 
 import Control.Monad.IO.Class qualified
@@ -68,17 +68,15 @@ addToStore
   :: MonadRemoteStore m
   => StorePathName        -- ^ Name part of the newly created `StorePath`
   -> NarSource IO         -- ^ Provide nar stream
-  -> FileIngestionMethod  -- ^ Add target directory recursively
-  -> Some HashAlgo        -- ^
-  -> RepairMode           -- ^ Only used by local store backend
+  -> ContentAddressMethod -- ^ Content addressing method
+  -> Some HashAlgo        -- ^ Hashing algorithm
+  -> Set StorePath        -- ^ References
+  -> RepairMode           -- ^ Whether to overwrite an existing valid path, repairing corruption.
+                          --   Sent to the daemon as part of the request since the 1.25 wire format.
   -> m StorePath
-addToStore name source method hashAlgo repair = do
-  Control.Monad.when
-    (repair == RepairMode_DoRepair)
-    $ throwError RemoteStoreError_RapairNotSupportedByRemoteStore
-
+addToStore name source method hashAlgo refs repair = do
   setNarSource source
-  doReq (AddToStore name method hashAlgo repair)
+  doReq (AddToStore name method hashAlgo refs repair)
 
 addToStoreNar
   :: MonadRemoteStore m

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Client/Core.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Client/Core.hs
@@ -27,9 +27,9 @@ import System.Nix.Store.Remote.Serializer
   ( bool
   , int
   , mapErrorS
+  , protoFeatures
   , protoVersion
   , validPathInfo
-  , set
   , storeRequest
   , text
   , trustedFlag
@@ -231,10 +231,10 @@ greetServer = do
   negotiatedFeatures <- if ProtoVersion 1 38 mempty `leq` leastCommonVersion
     then do
       sockPutS
-        (mapErrorS RemoteStoreError_SerializerPut (set text))
+        (mapErrorS RemoteStoreError_SerializerPut protoFeatures)
         (protoVersion_features pv)
       daemonFeatures <- sockGetS
-        $ mapErrorS RemoteStoreError_SerializerGet (set text)
+        $ mapErrorS RemoteStoreError_SerializerGet protoFeatures
       pure $ Data.Set.intersection daemonFeatures (protoVersion_features pv)
     else pure mempty
 

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Client/Core.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Client/Core.hs
@@ -4,11 +4,14 @@ module System.Nix.Store.Remote.Client.Core
   , doReq
   ) where
 
+import Algebra.PartialOrd (leq)
 import Control.Monad (unless, when)
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Bits (shiftR)
 import Data.ByteString (ByteString)
 import Data.DList (DList)
+import Data.Set qualified
 import Data.Some (Some(Some))
 import Data.Word (Word64)
 import Network.Socket (Socket)
@@ -25,6 +28,8 @@ import System.Nix.Store.Remote.Serializer
   , int
   , mapErrorS
   , protoVersion
+  , validPathInfo
+  , set
   , storeRequest
   , text
   , trustedFlag
@@ -33,7 +38,7 @@ import System.Nix.Store.Remote.Serializer
 import System.Nix.Store.Remote.Types.Handshake (ClientHandshakeOutput(..))
 import System.Nix.Store.Remote.Types.Logger (Logger)
 import System.Nix.Store.Remote.Types.NoReply (NoReply(..))
-import System.Nix.Store.Remote.Types.ProtoVersion (ProtoVersion(..))
+import System.Nix.Store.Remote.Types.ProtoVersion (ProtoVersion(..), minVersionNumber)
 import System.Nix.Store.Remote.Types.StoreRequest (StoreRequest(..))
 import System.Nix.Store.Remote.Types.StoreReply (StoreReply(..))
 import System.Nix.Store.Remote.Types.WorkerMagic (WorkerMagic(..))
@@ -66,19 +71,20 @@ doReq = \case
 
     case x of
       AddToStore {} -> do
-
         ms <- takeNarSource
+        soc <- getStoreSocket
         case ms of
-          Just (stream :: NarSource IO) -> do
-            soc <- getStoreSocket
-            liftIO
-              $ stream
-              $ Network.Socket.ByteString.sendAll soc
+          Just (stream :: NarSource IO) ->
+            liftIO $ writeFramedNarSource stream soc
           Nothing ->
             throwError
               RemoteStoreError_NoNarSourceProvided
         processOutput
-        processReply
+        -- New protocol returns ValidPathInfo (path + metadata)
+        (path, _metadata) <- sockGetS
+          $ mapErrorS RemoteStoreError_SerializerGet
+          $ validPathInfo storeDir
+        pure path
 
       AddToStoreNar _ meta _ _ -> do
         let narBytes = maybe 0 id $ metadataNarBytes meta
@@ -140,6 +146,29 @@ copyToSink sink remainingBytes soc =
     let nextRemainingBytes = remainingBytes - (fromIntegral . Data.ByteString.length) bytes
     copyToSink sink nextRemainingBytes soc
 
+-- | Write a NarSource as framed data to a socket.
+-- Each chunk of NAR data is prefixed with its length as a
+-- little-endian u64, terminated by a zero-length frame.
+writeFramedNarSource :: NarSource IO -> Socket -> IO ()
+writeFramedNarSource narSource sock = do
+  narSource sendChunk
+  sendWord64le sock 0 -- terminator
+  where
+    sendChunk :: ByteString -> IO ()
+    sendChunk bs = do
+      let len = Data.ByteString.length bs
+      when (len > 0) $ do
+        sendWord64le sock (fromIntegral len)
+        Network.Socket.ByteString.sendAll sock bs
+
+    sendWord64le :: Socket -> Word64 -> IO ()
+    sendWord64le s w =
+      Network.Socket.ByteString.sendAll s
+        $ Data.ByteString.pack
+            [ fromIntegral (shiftR w (i * 8))
+            | i <- [0..7]
+            ]
+
 writeFramedSource
   :: forall m
    . ( MonadIO m
@@ -190,45 +219,46 @@ greetServer = do
 
   daemonVersion <- sockGetS protoVersion
 
-  when (daemonVersion < ProtoVersion 1 10)
+  when (not (ProtoVersion 1 37 mempty `leq` daemonVersion))
     $ throwError RemoteStoreError_ClientVersionTooOld
 
   pv <- getProtoVersion
   sockPutS protoVersion pv
 
-  let leastCommonVersion = min daemonVersion pv
+  let leastCommonVersion = minVersionNumber daemonVersion pv
 
-  when (leastCommonVersion >= ProtoVersion 1 14)
-    $ sockPutS int (0 :: Int) -- affinity, obsolete
-
-  when (leastCommonVersion >= ProtoVersion 1 11) $ do
-    sockPutS
-      (mapErrorS RemoteStoreError_SerializerPut bool)
-      False -- reserveSpace, obsolete
-
-  daemonNixVersion <- if leastCommonVersion >= ProtoVersion 1 33
+  -- Feature exchange (>= 1.38)
+  negotiatedFeatures <- if ProtoVersion 1 38 mempty `leq` leastCommonVersion
     then do
-      -- If we were buffering I/O, we would flush the output here.
-      txtVer <-
-        sockGetS
-          $ mapErrorS
-              RemoteStoreError_SerializerGet
-              text
-      pure $ Just txtVer
-    else pure Nothing
+      sockPutS
+        (mapErrorS RemoteStoreError_SerializerPut (set text))
+        (protoVersion_features pv)
+      daemonFeatures <- sockGetS
+        $ mapErrorS RemoteStoreError_SerializerGet (set text)
+      pure $ Data.Set.intersection daemonFeatures (protoVersion_features pv)
+    else pure mempty
 
-  remoteTrustsUs <- if leastCommonVersion >= ProtoVersion 1 35
-    then do
-      sockGetS
-        $ mapErrorS RemoteStoreError_SerializerHandshake trustedFlag
-    else pure Nothing
+  let leastCommonVersionWithFeatures = leastCommonVersion { protoVersion_features = negotiatedFeatures }
 
-  setProtoVersion leastCommonVersion
+  setProtoVersion leastCommonVersionWithFeatures
+
+  -- postHandshake: affinity (obsolete), reserveSpace (obsolete)
+  sockPutS int (0 :: Int) -- affinity, obsolete
+  sockPutS (mapErrorS RemoteStoreError_SerializerPut bool) False -- reserveSpace, obsolete
+
+  -- If we were buffering I/O, we would flush the output here.
+
+  daemonNixVersion <- Just <$>
+    sockGetS (mapErrorS RemoteStoreError_SerializerGet text)
+
+  remoteTrustsUs <-
+    sockGetS (mapErrorS RemoteStoreError_SerializerHandshake trustedFlag)
+
   processOutput
 
   pure ClientHandshakeOutput
     { clientHandshakeOutputNixVersion = daemonNixVersion
     , clientHandshakeOutputTrust = remoteTrustsUs
-    , clientHandshakeOutputLeastCommonVersion = leastCommonVersion
+    , clientHandshakeOutputLeastCommonVersion = leastCommonVersionWithFeatures
     , clientHandshakeOutputServerVersion = daemonVersion
     }

--- a/hnix-store-remote/src/System/Nix/Store/Remote/MonadStore.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/MonadStore.hs
@@ -29,7 +29,7 @@ import Network.Socket (Socket)
 import System.Nix.Nar (NarSource)
 import System.Nix.StorePath (HasStoreDir(..), StoreDir)
 import System.Nix.Store.Remote.Serializer (HandshakeSError, LoggerSError, RequestSError, ReplySError, SError)
-import System.Nix.Store.Remote.Types.Logger (Logger, BasicError, ErrorInfo)
+import System.Nix.Store.Remote.Types.Logger (Logger, ErrorInfo)
 import System.Nix.Store.Remote.Types.ProtoVersion (HasProtoVersion(..), ProtoVersion)
 import System.Nix.Store.Remote.Types.StoreConfig (ProtoStoreConfig(..))
 
@@ -74,7 +74,7 @@ data RemoteStoreError
   | RemoteStoreError_SerializerRequest RequestSError
   | RemoteStoreError_SerializerReply ReplySError
   | RemoteStoreError_IOException SomeException
-  | RemoteStoreError_LoggerError (Either BasicError ErrorInfo)
+  | RemoteStoreError_LoggerError ErrorInfo
   | RemoteStoreError_LoggerLeftovers String ByteString -- when there are bytes left over after incremental logger parser is done, (Done x leftover), first param is show x
   | RemoteStoreError_LoggerParserFail String ByteString -- when incremental parser returns ((Fail msg leftover) :: Result)
   | RemoteStoreError_NoDataSourceProvided -- remoteStoreStateMDataSource is required but it is Nothing

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
@@ -42,6 +42,7 @@ module System.Nix.Store.Remote.Serializer
   , storePathName
   -- * Metadata
   , pathMetadata
+  , validPathInfo
   -- * OutputName
   , outputName
   -- * Signatures
@@ -67,7 +68,6 @@ module System.Nix.Store.Remote.Serializer
   , activityResult
   , field
   , trace
-  , basicError
   , errorInfo
   , loggerOpCode
   , logger
@@ -87,9 +87,7 @@ module System.Nix.Store.Remote.Serializer
   , opSuccess
   , noop
   -- *** Realisation
-  , buildTraceKeyTyped
   , realisation
-  , realisationWithId
   -- *** BuildResult
   , buildResult
   -- *** GCResult
@@ -148,20 +146,18 @@ import GHC.Generics (Generic)
 import System.Nix.Base (BaseEncoding(Base16, NixBase32))
 import System.Nix.Base qualified
 import System.Nix.Build (BuildMode, BuildResult(..), BuildSuccess(..), BuildFailure(..), BuildSuccessStatus(..), BuildFailureStatus(..))
-import System.Nix.ContentAddress (ContentAddress)
+import System.Nix.ContentAddress (ContentAddress, methodAlgoBuilder, methodAlgoParser)
 import System.Nix.ContentAddress qualified
 import System.Nix.Derivation.Traditional
 import System.Nix.Derivation
 import System.Nix.DerivedPath (DerivedPath(..), ParseOutputsError)
 import System.Nix.DerivedPath qualified
-import System.Nix.FileContentAddress (FileIngestionMethod(..))
 import System.Nix.Hash (HashAlgo(..))
 import System.Nix.Hash qualified
 import System.Nix.JSON ()
 import System.Nix.OutputName (OutputName)
 import System.Nix.OutputName qualified
-import System.Nix.Realisation (BuildTraceKey, BuildTraceKeyError, Realisation(..), RealisationWithId(..))
-import System.Nix.Realisation qualified
+import System.Nix.Realisation (Realisation(..))
 import System.Nix.Signature (Signature, NamedSignature)
 import System.Nix.Signature qualified
 import System.Nix.Store.Remote.Types
@@ -194,7 +190,6 @@ data SError
       }
   | SError_ContentAddress String
   | SError_DerivedPath ParseOutputsError
-  | SError_BuildTraceKey BuildTraceKeyError
   | SError_Digest String
   | SError_EnumOutOfMinBound Int
   | SError_EnumOutOfMaxBound Int
@@ -203,16 +198,11 @@ data SError
   | SError_InvalidNixBase32
   | SError_JSONDecoding String
   | SError_NarHashMustBeSHA256
-  | SError_NotYetImplemented String (ForPV ProtoVersion)
   | SError_Name InvalidNameError
   | SError_Path InvalidPathError
   | SError_Signature String
-  deriving (Eq, Ord, Generic, Show)
+  deriving (Eq, Generic, Show)
 
-data ForPV a
-  = ForPV_Newer a
-  | ForPV_Older a
-  deriving (Eq, Ord, Generic, Show)
 
 -- ** Runners
 
@@ -450,6 +440,7 @@ jsonP = AlmostPrism
 
 -- protoVersion_major & 0xFF00
 -- protoVersion_minor & 0x00FF
+-- Features are exchanged separately during handshake, not on wire here.
 protoVersion :: NixSerializer e ProtoVersion
 protoVersion = Serializer
   { getS = do
@@ -457,6 +448,7 @@ protoVersion = Serializer
       pure ProtoVersion
         { protoVersion_major = fromIntegral $ Data.Bits.shiftR v 8
         , protoVersion_minor = fromIntegral $ v Data.Bits..&. 0x00FF
+        , protoVersion_features = mempty
         }
   , putS = \p ->
       putS (int @Word32)
@@ -578,6 +570,20 @@ pathMetadata storeDir = Serializer
         (\case False -> BuiltElsewhere; True -> BuiltLocally)
         (\case BuiltElsewhere -> False; BuiltLocally -> True)
         bool
+
+-- | Read/write a full ValidPathInfo (StorePath + Metadata) as one unit.
+validPathInfo
+  :: StoreDir
+  -> NixSerializer SError (StorePath, Metadata StorePath)
+validPathInfo storeDir = Serializer
+  { getS = do
+      path <- getS (storePath storeDir)
+      metadata <- getS (pathMetadata storeDir)
+      pure (path, metadata)
+  , putS = \(path, metadata) -> do
+      putS (storePath storeDir) path
+      putS (pathMetadata storeDir) metadata
+  }
 
 -- * OutputName
 
@@ -731,23 +737,10 @@ derivedPathNew storeDir = Serializer
 
 derivedPath
   :: StoreDir
-  -> ProtoVersion
   -> NixSerializer SError DerivedPath
-derivedPath storeDir pv = Serializer
-  { getS =
-      if pv < ProtoVersion 1 30
-        then DerivedPath_Opaque <$> getS (storePath storeDir)
-        else getS $ derivedPathNew storeDir
-  , putS = \d ->
-      if pv < ProtoVersion 1 30
-        then case d of
-          DerivedPath_Opaque p -> putS (storePath storeDir) p
-          _ -> error "not yet implemented"
-          --     throwError
-          --      $ SError_NotYetImplemented
-          --          "DerivedPath_Built"
-          --          (ForPV_Older pv)
-        else putS (derivedPathNew storeDir) d
+derivedPath storeDir = Serializer
+  { getS = getS $ derivedPathNew storeDir
+  , putS = putS (derivedPathNew storeDir)
   }
 
 -- * Build
@@ -760,10 +753,8 @@ buildMode = enum
 data LoggerSError
   = LoggerSError_Prim SError
   | LoggerSError_InvalidOpCode Word64
-  | LoggerSError_TooOldForErrorInfo
-  | LoggerSError_TooNewForBasicError
   | LoggerSError_UnknownLogFieldType Word8
-  deriving (Eq, Ord, Generic, Show)
+  deriving (Eq, Generic, Show)
 
 mapPrimE
   :: Functor m
@@ -818,18 +809,6 @@ trace = Serializer
       putS text traceHint
   }
 
-basicError :: NixSerializer LoggerSError BasicError
-basicError = Serializer
-  { getS = do
-      basicErrorMessage <- mapPrimE $ getS text
-      basicErrorExitStatus <- getS int
-      pure BasicError{..}
-
-  , putS = \BasicError{..} -> do
-      putS text basicErrorMessage
-      putS int basicErrorExitStatus
-  }
-
 errorInfo :: NixSerializer LoggerSError ErrorInfo
 errorInfo = Serializer
   { getS = do
@@ -869,7 +848,7 @@ loggerOpCode = Serializer
 logger
   :: ProtoVersion
   -> NixSerializer LoggerSError Logger
-logger pv = Serializer
+logger _pv = Serializer
   { getS = getS loggerOpCode >>= \case
       LoggerOpCode_Next ->
         mapPrimE $
@@ -886,10 +865,7 @@ logger pv = Serializer
         pure Logger_Last
 
       LoggerOpCode_Error -> do
-        Logger_Error <$>
-          if protoVersion_minor pv >= 26
-          then Right <$> getS errorInfo
-          else Left <$> getS basicError
+        Logger_Error <$> getS errorInfo
 
       LoggerOpCode_StartActivity -> do
         startActivityID <- getS activityID
@@ -926,16 +902,9 @@ logger pv = Serializer
         Logger_Last ->
           putS loggerOpCode LoggerOpCode_Last
 
-        Logger_Error basicOrInfo -> do
+        Logger_Error e -> do
           putS loggerOpCode LoggerOpCode_Error
-
-          let minor = protoVersion_minor pv
-
-          case basicOrInfo of
-            Left _ | minor >= 26 -> error "protocol too new" -- throwError $ LoggerSError_TooNewForBasicError
-            Left e | otherwise -> putS basicError e
-            Right _ | minor < 26 -> error "protocol too old" -- throwError $ LoggerSError_TooOldForErrorInfo
-            Right e -> putS errorInfo e
+          putS errorInfo e
 
         Logger_StartActivity{..} -> do
           putS loggerOpCode LoggerOpCode_StartActivity
@@ -1019,24 +988,24 @@ data RequestSError
   | RequestSError_ReservedOp WorkerOp
   | RequestSError_PrimGet SError
   | RequestSError_PrimWorkerOp SError
-  deriving (Eq, Ord, Generic, Show)
+  deriving (Eq, Generic, Show)
 
 storeRequest
   :: StoreDir
   -> ProtoVersion
   -> NixSerializer RequestSError (Some StoreRequest)
-storeRequest storeDir pv = Serializer
+storeRequest storeDir _pv = Serializer
   { getS = withExceptT RequestSError_PrimWorkerOp (getS workerOp) >>= \case
       WorkerOp_AddToStore -> mapGetE $ do
         pathName <- getS storePathName
-        _fixed <- getS bool -- obsolete
-        recursive <- getS enum
-        hashAlgo <- getS someHashAlgo
-
-        -- not supported by ProtoVersion < 1.25
-        let repair = RepairMode_DontRepair
-
-        pure $ Some (AddToStore pathName recursive hashAlgo repair)
+        camStr <- getS text
+        (method, hashAlgo) <- case Data.Attoparsec.Text.parseOnly methodAlgoParser camStr of
+          Left e -> fail e
+          Right x -> pure x
+        refs <- getS (set (storePath storeDir))
+        repairBool <- getS bool
+        let repair = if repairBool then RepairMode_DoRepair else RepairMode_DontRepair
+        pure $ Some (AddToStore pathName method hashAlgo refs repair)
 
       WorkerOp_AddToStoreNar -> mapGetE $ do
         storePath' <- getS $ storePath storeDir
@@ -1066,7 +1035,7 @@ storeRequest storeDir pv = Serializer
         Some . AddTempRoot <$> getS (storePath storeDir)
 
       WorkerOp_BuildPaths -> mapGetE $ do
-        derived <- getS (set $ derivedPath storeDir pv)
+        derived <- getS (set $ derivedPath storeDir)
         buildMode' <- getS buildMode
         pure $ Some (BuildPaths derived buildMode')
 
@@ -1132,7 +1101,7 @@ storeRequest storeDir pv = Serializer
         Some . QueryPathFromHashPart <$> getS storePathHashPart
 
       WorkerOp_QueryMissing -> mapGetE $ do
-        Some . QueryMissing <$> getS (set $ derivedPath storeDir pv)
+        Some . QueryMissing <$> getS (set $ derivedPath storeDir)
 
       WorkerOp_OptimiseStore -> mapGetE $ do
         pure $ Some OptimiseStore
@@ -1170,18 +1139,16 @@ storeRequest storeDir pv = Serializer
       w@WorkerOp_SetOptions -> notYet w
 
   , putS = \case
-      Some (AddToStore pathName recursive hashAlgo _repair) -> do
+      Some (AddToStore pathName method hashAlgo refs repair) -> do
         putS workerOp WorkerOp_AddToStore
 
         putS storePathName pathName
-        -- obsolete fixed
-        putS bool
-          $ not
-          $ hashAlgo == Some HashAlgo_SHA256
-            && (recursive == FileIngestionMethod_NixArchive)
-
-        putS bool (recursive == FileIngestionMethod_NixArchive)
-        putS someHashAlgo hashAlgo
+        putS text
+          $ Data.Text.Lazy.toStrict
+          $ Data.Text.Lazy.Builder.toLazyText
+          $ methodAlgoBuilder method hashAlgo
+        putS (set (storePath storeDir)) refs
+        putS bool (repair == RepairMode_DoRepair)
 
       Some (AddToStoreNar storePath' metadata repair checkSigs) -> do
         putS workerOp WorkerOp_AddToStoreNar
@@ -1214,7 +1181,7 @@ storeRequest storeDir pv = Serializer
       Some (BuildPaths derived buildMode') -> do
         putS workerOp WorkerOp_BuildPaths
 
-        putS (set $ derivedPath storeDir pv) derived
+        putS (set $ derivedPath storeDir) derived
         putS buildMode buildMode'
 
       Some (BuildDerivation path drv0 buildMode') -> do
@@ -1291,7 +1258,7 @@ storeRequest storeDir pv = Serializer
 
       Some (QueryMissing derived) -> do
         putS workerOp WorkerOp_QueryMissing
-        putS (set $ derivedPath storeDir pv) derived
+        putS (set $ derivedPath storeDir) derived
 
       Some OptimiseStore -> do
         putS workerOp WorkerOp_OptimiseStore
@@ -1327,14 +1294,13 @@ storeRequest storeDir pv = Serializer
 
 data ReplySError
   = ReplySError_PrimGet SError
-  | ReplySError_BuildTraceKey SError
   | ReplySError_GCResult SError
   | ReplySError_Metadata SError
   | ReplySError_Missing SError
   | ReplySError_Realisation SError
   | ReplySError_RealisationWithId SError
   | ReplySError_UnexpectedFalseOpSuccess
-  deriving (Eq, Ord, Generic, Show)
+  deriving (Eq, Generic, Show)
 
 mapGetER
   :: Functor m
@@ -1364,27 +1330,8 @@ noop ret = Serializer
 
 -- *** Realisation
 
-buildTraceKeyTyped :: NixSerializer ReplySError BuildTraceKey
-buildTraceKeyTyped = mapErrorS ReplySError_BuildTraceKey $
-  mapPrismSerializer
-    AlmostPrism
-    { _almostPrism_get =
-      ExceptT
-      . Identity
-      . Data.Bifunctor.first SError_BuildTraceKey
-      . System.Nix.Realisation.buildTraceKeyParser
-    , _almostPrism_put =
-      Data.Text.Lazy.toStrict
-      . Data.Text.Lazy.Builder.toLazyText
-      . System.Nix.Realisation.buildTraceKeyBuilder
-    }
-    text
-
 realisation :: NixSerializer ReplySError Realisation
 realisation = mapErrorS ReplySError_Realisation json
-
-realisationWithId :: NixSerializer ReplySError RealisationWithId
-realisationWithId = mapErrorS ReplySError_RealisationWithId json
 
 -- *** BuildResult
 
@@ -1402,25 +1349,17 @@ buildResult _storeDir pv = Serializer
         , buildResultStartTime
         , buildResultStopTime
         ) <-
-        if protoVersion_minor pv >= 29
-        then mapGetER $ do
+        mapGetER $ do
           tb <- getS int
           nondet <- getS bool
           start <- (\case x | x == t0 -> Nothing; x -> Just x) <$> getS time
           end <- (\case x | x == t0 -> Nothing; x -> Just x) <$> getS time
           pure $ (tb, nondet, start, end)
-        else pure $ (0, False, Nothing, Nothing)
 
+      Control.Monad.unless (hasFeature featureRealisationWithPath pv)
+        $ fail "missing required feature: realisation-with-path-not-hash"
       parsedBuiltOutputs <-
-        if protoVersion_minor pv >= 28
-        then do
-          wireMap <- getS (mapS buildTraceKeyTyped realisationWithId)
-          pure
-            $ Data.Map.Strict.fromList
-            $ map (\(btk, RealisationWithId (_btk, r)) ->
-                    (System.Nix.Realisation.buildTraceKeyOutput btk, r))
-            $ Data.Map.Strict.toList wireMap
-        else pure mempty
+        getS (mapS (mapErrorS ReplySError_PrimGet outputName) realisation)
 
       let buildResultStatus = case (wireToStatus statusWord, errorMessage) of
             (Right successStatus, _) -> Right $ BuildSuccess successStatus parsedBuiltOutputs
@@ -1448,16 +1387,14 @@ buildResult _storeDir pv = Serializer
 
       putS enum statusWord
       putS maybeText errorMessage
-      Control.Monad.when (protoVersion_minor pv >= 29) $ do
-        putS int buildResultTimesBuilt
-        putS bool isNonDeterministic
-        putS time buildResultStartTime
-        putS time buildResultStopTime
-      -- TODO: builtOutputs serialization requires drvPath context to
-      -- reconstruct BuildTraceKey from OutputName
-      Control.Monad.when (protoVersion_minor pv >= 28)
-        $ putS (mapS buildTraceKeyTyped realisationWithId)
-          (mempty :: Data.Map.Strict.Map BuildTraceKey RealisationWithId)
+      putS int buildResultTimesBuilt
+      putS bool isNonDeterministic
+      putS time buildResultStartTime
+      putS time buildResultStopTime
+      let builtOutputs = case buildResultStatus of
+            Right (BuildSuccess _ bo) -> bo
+            Left _ -> mempty
+      putS (mapS (mapErrorS ReplySError_PrimGet outputName) realisation) builtOutputs
   }
   where
     t0 :: UTCTime

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
@@ -35,6 +35,8 @@ module System.Nix.Store.Remote.Serializer
   , json
   -- * ProtoVersion
   , protoVersion
+  , protoFeature
+  , protoFeatures
   -- * StorePath
   , storePath
   , maybePath
@@ -201,6 +203,7 @@ data SError
   | SError_Name InvalidNameError
   | SError_Path InvalidPathError
   | SError_Signature String
+  | SError_UnknownProtoFeature Text
   deriving (Eq, Generic, Show)
 
 
@@ -454,6 +457,37 @@ protoVersion = Serializer
       putS (int @Word32)
       $ ((Data.Bits.shiftL (fromIntegral $ protoVersion_major p :: Word32) 8)
           Data.Bits..|. fromIntegral (protoVersion_minor p))
+  }
+
+protoFeature :: NixSerializer SError ProtoFeature
+protoFeature =
+  mapPrismSerializer
+    (AlmostPrism
+      (\t ->
+        maybe
+          (throwError $ SError_UnknownProtoFeature t)
+          pure
+          (protoFeatureFromText t)
+      )
+      protoFeatureToText
+    )
+    text
+
+-- | Features advertised by the other side during handshake.
+--
+-- Unknown features are dropped rather than rejected. The peer may
+-- support features we do not know about, and negotiation intersects
+-- with our own feature set anyway.
+protoFeatures :: NixSerializer SError (Set ProtoFeature)
+protoFeatures = Serializer
+  { getS =
+      Data.Set.fromList
+      . Data.Maybe.mapMaybe protoFeatureFromText
+      <$> getS (list text)
+  , putS =
+      putS (list text)
+      . fmap protoFeatureToText
+      . Data.Set.toList
   }
 
 -- * StorePath
@@ -1356,7 +1390,7 @@ buildResult _storeDir pv = Serializer
           end <- (\case x | x == t0 -> Nothing; x -> Just x) <$> getS time
           pure $ (tb, nondet, start, end)
 
-      Control.Monad.unless (hasFeature featureRealisationWithPath pv)
+      Control.Monad.unless (hasFeature ProtoFeature_RealisationWithPathNotHash pv)
         $ fail "missing required feature: realisation-with-path-not-hash"
       parsedBuiltOutputs <-
         getS (mapS (mapErrorS ReplySError_PrimGet outputName) realisation)

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Server.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Server.hs
@@ -6,8 +6,9 @@ module System.Nix.Store.Remote.Server
   )
   where
 
+import Algebra.PartialOrd (leq)
 import Control.Concurrent.Classy.Async
-import Control.Monad (join, void, when)
+import Control.Monad (join, unless, void, when)
 import Control.Monad.Conc.Class (MonadConc)
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.Trans (lift)
@@ -15,25 +16,27 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Default.Class (Default(def))
 import Data.Foldable (traverse_)
 import Data.IORef (IORef, atomicModifyIORef, newIORef)
+import Data.Set qualified
 import Data.Text (Text)
 import Data.Void (Void, absurd)
-import Data.Word (Word32)
+import Data.ByteString (ByteString)
+import Data.Word (Word32, Word64)
 import Network.Socket (Socket, accept, close, listen, maxListenQueue)
 import System.Nix.Nar (NarSource)
 import System.Nix.Store.Remote.Client (Run, doReq)
-import System.Nix.Store.Remote.Serializer (LoggerSError, mapErrorS, storeRequest, workerMagic, protoVersion, int, logger, text, trustedFlag)
+import System.Nix.Store.Remote.Serializer (LoggerSError, mapErrorS, storeRequest, validPathInfo, workerMagic, protoVersion, int, set, logger, text, trustedFlag)
 import System.Nix.Store.Remote.Socket
 import System.Nix.Store.Remote.Types.StoreRequest as R
 import System.Nix.Store.Remote.Types.StoreReply
-import System.Nix.Store.Remote.Types.ProtoVersion (ProtoVersion(..))
-import System.Nix.Store.Remote.Types.Logger (BasicError(..), ErrorInfo, Logger(..))
+import System.Nix.Store.Remote.Types.ProtoVersion (ProtoVersion(..), minVersionNumber)
+import System.Nix.Store.Remote.Types.Logger (ErrorInfo, Logger(..))
 import System.Nix.Store.Remote.MonadStore (MonadRemoteStore(..), WorkerError(..), WorkerException(..), RemoteStoreError(..), RemoteStoreT, runRemoteStoreT)
 import System.Nix.Store.Remote.Types.Handshake (ServerHandshakeInput(..), ServerHandshakeOutput(..))
 import System.Nix.Store.Remote.Types.WorkerMagic (WorkerMagic(..))
 import Data.Some qualified
-import Data.Text qualified
 import Data.Text.IO qualified
-import System.Timeout qualified
+import Data.Bits (shiftL)
+import Data.ByteString qualified
 import Network.Socket.ByteString qualified
 
 type WorkerHelper m
@@ -124,19 +127,8 @@ processConnection workerHelper postGreet sock = do
 
           special <- case req of
             AddToStore {} -> do
-              -- This is a hack (but a pretty neat and fast one!)
-              -- it should parse nad stream NAR instead
               let proxyNarSource :: NarSource IO
-                  proxyNarSource f =
-                    liftIO
-                      (System.Timeout.timeout
-                         1000000
-                         (Network.Socket.ByteString.recv sock 8)
-                      )
-                    >>= \case
-                      Nothing -> pure ()
-                      Just x -> f x >> proxyNarSource f
-
+                  proxyNarSource sink = readFramedSource sock sink
               pure $ setNarSource proxyNarSource
             _ -> pure $ pure ()
 
@@ -152,12 +144,28 @@ processConnection workerHelper postGreet sock = do
             Right reply -> do
               storeDir <- getStoreDir
               pv <- getProtoVersion
-              sockPutS
-                (mapErrorS
-                   RemoteStoreError_SerializerReply
-                   $ getReplyS storeDir pv
-                )
-                reply
+              case req of
+                -- AddToStore returns ValidPathInfo on the wire,
+                -- not just StorePath
+                AddToStore {} -> do
+                  -- Query the metadata so we can send full ValidPathInfo
+                  metadata <- lift $ workerHelper $ doReq (QueryPathInfo reply)
+                  case fst metadata of
+                    Left e -> throwError e
+                    Right (Just meta) ->
+                      sockPutS
+                        (mapErrorS RemoteStoreError_SerializerPut
+                          $ validPathInfo storeDir)
+                        (reply, meta)
+                    Right Nothing ->
+                      throwError $ RemoteStoreError_Fixme "AddToStore: path not found after adding"
+                _ ->
+                  sockPutS
+                    (mapErrorS
+                       RemoteStoreError_SerializerReply
+                       $ getReplyS storeDir pv
+                    )
+                    reply
 
     -- Process client requests.
     let loop = do
@@ -234,42 +242,45 @@ processConnection workerHelper postGreet sock = do
 
       clientVersion <- sockGetS protoVersion
 
-      let leastCommonVersion = min clientVersion serverHandshakeInputOurVersion
+      let leastCommonVersion = minVersionNumber clientVersion serverHandshakeInputOurVersion
 
-      when (clientVersion < ProtoVersion 1 10)
+      when (not (ProtoVersion 1 37 mempty `leq` clientVersion))
         $ throwError
         $ RemoteStoreError_WorkerException
             WorkerException_ClientVersionTooOld
 
-      when (clientVersion >= ProtoVersion 1 14) $ do
-        x :: Word32 <- sockGetS int
-        when (x /= 0) $ do
-          -- Obsolete CPU affinity.
-          _ :: Word32 <- sockGetS int
-          pure ()
+      -- Feature exchange (>= 1.38)
+      negotiatedFeatures <- if ProtoVersion 1 38 mempty `leq` leastCommonVersion
+        then do
+          clientFeatures <- sockGetS
+            $ mapErrorS RemoteStoreError_SerializerGet (set text)
+          sockPutS
+            (mapErrorS RemoteStoreError_SerializerPut (set text))
+            (protoVersion_features serverHandshakeInputOurVersion)
+          pure $ Data.Set.intersection clientFeatures (protoVersion_features serverHandshakeInputOurVersion)
+        else pure mempty
 
-      when (clientVersion >= ProtoVersion 1 11) $ do
-        _ :: Word32 <- sockGetS int -- obsolete reserveSpace
+      let leastCommonVersionWithFeatures = leastCommonVersion { protoVersion_features = negotiatedFeatures }
+
+      -- postHandshake: read affinity (obsolete), reserveSpace (obsolete)
+      x :: Word32 <- sockGetS int
+      when (x /= 0) $ do
+        -- Obsolete CPU affinity.
+        _ :: Word32 <- sockGetS int
         pure ()
 
-      when (clientVersion >= ProtoVersion 1 33) $ do
-        sockPutS
-          (mapErrorS
-             RemoteStoreError_SerializerPut
-             text
-          )
-          serverHandshakeInputNixVersion
+      _ :: Word32 <- sockGetS int -- obsolete reserveSpace
 
-      when (clientVersion >= ProtoVersion 1 35) $ do
-        sockPutS
-          (mapErrorS
-             RemoteStoreError_SerializerHandshake
-             trustedFlag
-          )
-          serverHandshakeInputTrust
+      sockPutS
+        (mapErrorS RemoteStoreError_SerializerPut text)
+        serverHandshakeInputNixVersion
+
+      sockPutS
+        (mapErrorS RemoteStoreError_SerializerHandshake trustedFlag)
+        serverHandshakeInputTrust
 
       pure ServerHandshakeOutput
-        { serverHandshakeOutputLeastCommonVersion = leastCommonVersion
+        { serverHandshakeOutputLeastCommonVersion = leastCommonVersionWithFeatures
         , serverHandshakeOutputClientVersion = clientVersion
         }
 
@@ -359,9 +370,7 @@ _stopWorkOnError x ex = updateLogger x $ \st ->
     True -> (,) (TunnelLoggerState False []) $ do
       pv <- getProtoVersion
       let logger' = mapErrorS RemoteStoreError_SerializerLogger (logger pv)
-      if protoVersion_minor pv >= 26
-        then sockPutS logger' (Logger_Error (Right ex))
-        else sockPutS logger' (Logger_Error (Left (BasicError 0 (Data.Text.pack $ show ex))))
+      sockPutS logger' (Logger_Error ex)
       pure True
 
 updateLogger
@@ -370,3 +379,46 @@ updateLogger
   -> (TunnelLoggerState -> (TunnelLoggerState, m a))
   -> m a
 updateLogger x = join . liftIO . atomicModifyIORef (_tunnelLogger_state x)
+
+-- | Read framed source data from a socket.
+--
+-- The framed protocol sends chunks as: little-endian u64 length
+-- followed by that many raw bytes, terminated by a zero-length frame.
+readFramedSource
+  :: Socket
+  -> (ByteString -> IO ())
+  -> IO ()
+readFramedSource sock sink = go
+  where
+    go = do
+      chunkLen <- recvWord64le sock
+      unless (chunkLen == 0) $ do
+        recvExact sock (fromIntegral chunkLen) sink
+        go
+
+    recvWord64le :: Socket -> IO Word64
+    recvWord64le s = do
+      bs <- recvExactBS s 8
+      pure $ sum
+        [ fromIntegral (Data.ByteString.index bs i) `shiftL` (i * 8)
+        | i <- [0..7]
+        ]
+
+    recvExactBS :: Socket -> Int -> IO ByteString
+    recvExactBS s n = do
+      bs <- Network.Socket.ByteString.recv s n
+      let got = Data.ByteString.length bs
+      if got == 0 then fail "readFramedSource: unexpected EOF"
+      else if got == n then pure bs
+      else do
+        rest <- recvExactBS s (n - got)
+        pure $ bs <> rest
+
+    recvExact :: Socket -> Int -> (ByteString -> IO ()) -> IO ()
+    recvExact s remaining f = when (remaining > 0) $ do
+      let toRead = min 16384 remaining
+      bs <- Network.Socket.ByteString.recv s toRead
+      let got = Data.ByteString.length bs
+      when (got == 0) $ fail "readFramedSource: unexpected EOF"
+      f bs
+      recvExact s (remaining - got) f

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Server.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Server.hs
@@ -24,7 +24,7 @@ import Data.Word (Word32, Word64)
 import Network.Socket (Socket, accept, close, listen, maxListenQueue)
 import System.Nix.Nar (NarSource)
 import System.Nix.Store.Remote.Client (Run, doReq)
-import System.Nix.Store.Remote.Serializer (LoggerSError, mapErrorS, storeRequest, validPathInfo, workerMagic, protoVersion, int, set, logger, text, trustedFlag)
+import System.Nix.Store.Remote.Serializer (LoggerSError, mapErrorS, storeRequest, validPathInfo, workerMagic, protoFeatures, protoVersion, int, logger, text, trustedFlag)
 import System.Nix.Store.Remote.Socket
 import System.Nix.Store.Remote.Types.StoreRequest as R
 import System.Nix.Store.Remote.Types.StoreReply
@@ -253,9 +253,9 @@ processConnection workerHelper postGreet sock = do
       negotiatedFeatures <- if ProtoVersion 1 38 mempty `leq` leastCommonVersion
         then do
           clientFeatures <- sockGetS
-            $ mapErrorS RemoteStoreError_SerializerGet (set text)
+            $ mapErrorS RemoteStoreError_SerializerGet protoFeatures
           sockPutS
-            (mapErrorS RemoteStoreError_SerializerPut (set text))
+            (mapErrorS RemoteStoreError_SerializerPut protoFeatures)
             (protoVersion_features serverHandshakeInputOurVersion)
           pure $ Data.Set.intersection clientFeatures (protoVersion_features serverHandshakeInputOurVersion)
         else pure mempty

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/Handshake.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/Handshake.hs
@@ -13,7 +13,7 @@ import System.Nix.Store.Remote.Types.TrustedFlag (TrustedFlag)
 -- | Data sent by the client during initial protocol handshake
 data ClientHandshakeInput = ClientHandshakeInput
   { clientHandshakeInputOurVersion :: ProtoVersion -- ^ Our protocol version (that we advertise to the server)
-  } deriving (Eq, Generic, Ord, Show)
+  } deriving (Eq, Generic, Show)
 
 -- | Data received by the client via initial protocol handshake
 data ClientHandshakeOutput = ClientHandshakeOutput
@@ -21,17 +21,17 @@ data ClientHandshakeOutput = ClientHandshakeOutput
   , clientHandshakeOutputTrust :: Maybe TrustedFlag -- ^ Whether remote side trusts us
   , clientHandshakeOutputLeastCommonVersion :: ProtoVersion -- ^ Minimum protocol version supported by both sides
   , clientHandshakeOutputServerVersion :: ProtoVersion -- ^ Protocol version supported by the server
-  } deriving (Eq, Generic, Ord, Show)
+  } deriving (Eq, Generic, Show)
 
 -- | Data sent by the server during initial protocol handshake
 data ServerHandshakeInput = ServerHandshakeInput
   { serverHandshakeInputNixVersion :: Text -- ^ Textual version, since 1.33
   , serverHandshakeInputOurVersion :: ProtoVersion -- ^ Our protocol version (that we advertise to the client)
   , serverHandshakeInputTrust :: Maybe TrustedFlag -- ^ Whether client should trusts us
-  } deriving (Eq, Generic, Ord, Show)
+  } deriving (Eq, Generic, Show)
 
 -- | Data received by the server during initial protocol handshake
 data ServerHandshakeOutput = ServerHandshakeOutput
   { serverHandshakeOutputLeastCommonVersion :: ProtoVersion -- ^ Minimum protocol version supported by both sides
   , serverHandshakeOutputClientVersion :: ProtoVersion -- ^ Protocol version supported by the client
-  } deriving (Eq, Generic, Ord, Show)
+  } deriving (Eq, Generic, Show)

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/Logger.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/Logger.hs
@@ -1,7 +1,6 @@
 module System.Nix.Store.Remote.Types.Logger
   ( Field(..)
   , Trace(..)
-  , BasicError(..)
   , ErrorInfo(..)
   , Logger(..)
   , LoggerOpCode(..)
@@ -29,14 +28,7 @@ data Trace = Trace
   }
   deriving (Eq, Generic, Ord, Show)
 
-data BasicError = BasicError
-  { basicErrorExitStatus :: Int
-  , basicErrorMessage :: Text
-  }
-  deriving (Eq, Generic, Ord, Show)
-
 -- | Extended error info
--- available for protoVersion_minor >= 26
 data ErrorInfo = ErrorInfo
   { errorInfoLevel :: Verbosity
   , errorInfoMessage :: Text
@@ -84,7 +76,7 @@ data Logger
   | Logger_Read Word64      -- data needed from source
   | Logger_Write ByteString -- data for sink
   | Logger_Last
-  | Logger_Error (Either BasicError ErrorInfo)
+  | Logger_Error ErrorInfo
   | Logger_StartActivity
       { startActivityID :: ActivityID
       , startActivityVerbosity :: Verbosity

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/ProtoVersion.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/ProtoVersion.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 module System.Nix.Store.Remote.Types.ProtoVersion
   ( ProtoVersion(..)
+  , ProtoFeature(..)
+  , protoFeatureToText
+  , protoFeatureFromText
   , HasProtoVersion(..)
-  , featureRealisationWithPath
   , hasFeature
   , minVersionNumber
   ) where
@@ -15,10 +17,25 @@ import Data.Text (Text)
 import Data.Word (Word8, Word16)
 import GHC.Generics (Generic)
 
+-- | An optional protocol capability, negotiated during handshake.
+data ProtoFeature
+  = ProtoFeature_RealisationWithPathNotHash
+  -- ^ Use StorePath-based realisations instead of hash-based ones.
+  deriving (Bounded, Enum, Eq, Generic, Ord, Show)
+
+-- | The name of a feature as exchanged on the wire.
+protoFeatureToText :: ProtoFeature -> Text
+protoFeatureToText = \case
+  ProtoFeature_RealisationWithPathNotHash -> "realisation-with-path-not-hash"
+
+protoFeatureFromText :: Text -> Maybe ProtoFeature
+protoFeatureFromText t =
+  lookup t [ (protoFeatureToText f, f) | f <- [minBound .. maxBound] ]
+
 data ProtoVersion = ProtoVersion
   { protoVersion_major :: Word16
   , protoVersion_minor :: Word8
-  , protoVersion_features :: Set Text
+  , protoVersion_features :: Set ProtoFeature
   }
   deriving (Eq, Generic, Show)
 
@@ -28,13 +45,8 @@ instance PartialOrd ProtoVersion where
       <= (protoVersion_major b, protoVersion_minor b)
     && protoVersion_features a `Data.Set.isSubsetOf` protoVersion_features b
 
--- | The feature for using StorePath-based realisations
--- instead of hash-based ones.
-featureRealisationWithPath :: Text
-featureRealisationWithPath = "realisation-with-path-not-hash"
-
 -- | Check whether a protocol version includes a given feature.
-hasFeature :: Text -> ProtoVersion -> Bool
+hasFeature :: ProtoFeature -> ProtoVersion -> Bool
 hasFeature f = Data.Set.member f . protoVersion_features
 
 -- | Take the minimum by version number, with empty features.
@@ -51,7 +63,7 @@ instance Default ProtoVersion where
   def = ProtoVersion
     { protoVersion_major = 1
     , protoVersion_minor = 38
-    , protoVersion_features = Data.Set.singleton featureRealisationWithPath
+    , protoVersion_features = Data.Set.singleton ProtoFeature_RealisationWithPathNotHash
     }
 
 class HasProtoVersion r where

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/ProtoVersion.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/ProtoVersion.hs
@@ -1,23 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
 module System.Nix.Store.Remote.Types.ProtoVersion
   ( ProtoVersion(..)
   , HasProtoVersion(..)
+  , featureRealisationWithPath
+  , hasFeature
+  , minVersionNumber
   ) where
 
+import Algebra.PartialOrd (PartialOrd(..))
 import Data.Default.Class (Default(def))
+import Data.Set (Set)
+import Data.Set qualified
+import Data.Text (Text)
 import Data.Word (Word8, Word16)
 import GHC.Generics (Generic)
 
 data ProtoVersion = ProtoVersion
   { protoVersion_major :: Word16
   , protoVersion_minor :: Word8
+  , protoVersion_features :: Set Text
   }
-  deriving (Eq, Generic, Ord, Show)
+  deriving (Eq, Generic, Show)
+
+instance PartialOrd ProtoVersion where
+  leq a b =
+    (protoVersion_major a, protoVersion_minor a)
+      <= (protoVersion_major b, protoVersion_minor b)
+    && protoVersion_features a `Data.Set.isSubsetOf` protoVersion_features b
+
+-- | The feature for using StorePath-based realisations
+-- instead of hash-based ones.
+featureRealisationWithPath :: Text
+featureRealisationWithPath = "realisation-with-path-not-hash"
+
+-- | Check whether a protocol version includes a given feature.
+hasFeature :: Text -> ProtoVersion -> Bool
+hasFeature f = Data.Set.member f . protoVersion_features
+
+-- | Take the minimum by version number, with empty features.
+-- Used in handshake before feature negotiation.
+minVersionNumber :: ProtoVersion -> ProtoVersion -> ProtoVersion
+minVersionNumber a b =
+  let (major', minor') = min
+        (protoVersion_major a, protoVersion_minor a)
+        (protoVersion_major b, protoVersion_minor b)
+  in ProtoVersion major' minor' mempty
 
 -- | The protocol version we support
 instance Default ProtoVersion where
   def = ProtoVersion
     { protoVersion_major = 1
-    , protoVersion_minor = 24
+    , protoVersion_minor = 38
+    , protoVersion_features = Data.Set.singleton featureRealisationWithPath
     }
 
 class HasProtoVersion r where

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/StoreConfig.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/StoreConfig.hs
@@ -24,7 +24,7 @@ instance HasStoreSocket Socket where
 data ProtoStoreConfig = ProtoStoreConfig
   { protoStoreConfigDir :: StoreDir
   , protoStoreConfigProtoVersion :: ProtoVersion
-  } deriving (Eq, Generic, Ord, Show)
+  } deriving (Eq, Generic, Show)
 
 instance Default ProtoStoreConfig where
   def = ProtoStoreConfig def def

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/StoreRequest.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/StoreRequest.hs
@@ -17,9 +17,9 @@ import Data.Some (Some(Some))
 import System.Nix.Build (BuildMode, BuildResult)
 import System.Nix.Derivation (BasicDerivation)
 import System.Nix.DerivedPath (DerivedPath)
+import System.Nix.ContentAddress (ContentAddressMethod)
 import System.Nix.Hash (HashAlgo)
 import System.Nix.Signature (Signature)
-import System.Nix.FileContentAddress (FileIngestionMethod)
 import System.Nix.Store.Types (RepairMode)
 import System.Nix.StorePath (StorePath, StorePathName, StorePathHashPart)
 import System.Nix.StorePath.Metadata (Metadata)
@@ -35,9 +35,10 @@ data StoreRequest :: Type -> Type where
   -- | Add @NarSource@ to the store.
   AddToStore
     :: StorePathName -- ^ Name part of the newly created @StorePath@
-    -> FileIngestionMethod -- ^ Add target directory recursively
-    -> Some HashAlgo -- ^ Nar hashing algorithm
-    -> RepairMode -- ^ Only used by local store backend
+    -> ContentAddressMethod -- ^ Content addressing method
+    -> Some HashAlgo -- ^ Hashing algorithm
+    -> Set StorePath -- ^ References
+    -> RepairMode
     -> StoreRequest StorePath
 
   -- | Add a NAR with Metadata to the store.
@@ -172,7 +173,7 @@ deriveGCompare ''StoreRequest
 deriveGShow ''StoreRequest
 
 instance {-# OVERLAPPING #-} Eq (Some StoreRequest) where
-  Some (AddToStore a b c d) == Some (AddToStore a' b' c' d') = (a, b, c, d) == (a', b', c', d')
+  Some (AddToStore a b c d e) == Some (AddToStore a' b' c' d' e') = (a, b, c, d, e) == (a', b', c', d', e')
   Some (AddToStoreNar a b c d) == Some (AddToStoreNar a' b' c' d') = (a, b, c, d) == (a', b', c', d')
   Some (AddTextToStore a b c) == Some (AddTextToStore a' b' c') = (a, b, c) == (a', b', c')
   Some (AddSignatures a b) == Some (AddSignatures a' b') = (a, b) == (a', b')

--- a/hnix-store-remote/tests-io/NixDaemonSpec.hs
+++ b/hnix-store-remote/tests-io/NixDaemonSpec.hs
@@ -22,7 +22,7 @@ import System.Linux.Namespaces (Namespace(..), GroupMapping(..), UserMapping(..)
 import System.Nix.Hash (HashAlgo(HashAlgo_SHA256))
 import System.Nix.Build (BuildMode(..))
 import System.Nix.DerivedPath (DerivedPath(..))
-import System.Nix.FileContentAddress (FileIngestionMethod(..))
+import System.Nix.ContentAddress (ContentAddressMethod(..))
 import System.Nix.StorePath (StoreDir(..), StorePath)
 import System.Nix.StorePath.Metadata (Metadata(..))
 import System.Nix.Store.Remote
@@ -291,8 +291,9 @@ dummy = do
   addToStore
     (forceRight $ System.Nix.StorePath.mkStorePathName "dummy")
     (System.Nix.Nar.dumpPath "dummy")
-    FileIngestionMethod_Flat
+    ContentAddressMethod_NixArchive
     (Some HashAlgo_SHA256)
+    mempty
     RepairMode_DontRepair
 
 invalidPath :: StorePath
@@ -458,8 +459,9 @@ makeProtoSpec f flavor = around f $ do
       addToStore
         (forceRight $ System.Nix.StorePath.mkStorePathName "tmp-addition")
         (System.Nix.Nar.dumpPath fp)
-        FileIngestionMethod_Flat
+        ContentAddressMethod_NixArchive
         (Some HashAlgo_SHA256)
+        mempty
         RepairMode_DontRepair
 
   context "with dummy" $ do

--- a/hnix-store-remote/tests/NixSerializerSpec.hs
+++ b/hnix-store-remote/tests/NixSerializerSpec.hs
@@ -3,21 +3,20 @@
 module NixSerializerSpec (spec) where
 
 import Crypto.Hash (MD5, SHA1, SHA256, SHA512)
-import Data.Some (Some(Some))
+import Data.Set qualified
+import Data.Some (Some)
 import Data.Time (UTCTime)
 import Test.Hspec (Expectation, Spec, describe, parallel, shouldBe)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck (Gen, arbitrary, forAll, suchThat)
 
-import Data.Time.Clock.POSIX qualified
-
 import System.Nix.Arbitrary ()
-import System.Nix.Build (BuildResult(..), BuildSuccess(..), BuildFailure(..))
+import System.Nix.Build (BuildResult(..), BuildSuccess(..))
 import System.Nix.Derivation.Traditional qualified
 import System.Nix.Store.Remote.Arbitrary ()
 import System.Nix.Store.Remote.Serializer
-import System.Nix.Store.Remote.Types.Logger (Logger(..))
-import System.Nix.Store.Remote.Types.ProtoVersion (ProtoVersion(..))
+import System.Nix.Store.Remote.Types.Logger ()
+import System.Nix.Store.Remote.Types.ProtoVersion (ProtoVersion(..), featureRealisationWithPath)
 import System.Nix.Store.Remote.Types.StoreRequest (StoreRequest(..))
 
 -- | Test for roundtrip using @NixSerializer@
@@ -54,48 +53,18 @@ spec = parallel $ do
   describe "Complex" $ do
     prop "DSum HashAlgo Digest" $ roundtripS namedDigest
 
-    describe "BuildResult" $ do
-      prop "< 1.28"
-        $ \sd -> forAll (arbitrary `suchThat` ((< 28) . protoVersion_minor))
-        $ \pv ->
-            roundtripS (buildResult sd pv)
-            . (\x -> x { buildResultStatus = case buildResultStatus x of
-                          Right (BuildSuccess st _bo) -> Right (BuildSuccess st mempty)
-                          Left (BuildFailure st em _nd) -> Left (BuildFailure st em False)
-                       })
-            . (\x -> x { buildResultTimesBuilt = 0
-                       , buildResultStartTime = Data.Time.Clock.POSIX.posixSecondsToUTCTime 0
-                       , buildResultStopTime = Data.Time.Clock.POSIX.posixSecondsToUTCTime 0
-                       , buildResultCpuUser = Nothing
-                       , buildResultCpuSystem = Nothing
-                       }
-              )
-      prop "= 1.28"
-        $ \sd ->
-            roundtripS (buildResult sd (ProtoVersion 1 28))
-            . (\x -> x { buildResultStatus = case buildResultStatus x of
-                          Right (BuildSuccess st _bo) -> Right (BuildSuccess st mempty)
-                          Left (BuildFailure st em _nd) -> Left (BuildFailure st em False)
-                       })
-            . (\x -> x { buildResultTimesBuilt = 0
-                       , buildResultStartTime = Data.Time.Clock.POSIX.posixSecondsToUTCTime 0
-                       , buildResultStopTime = Data.Time.Clock.POSIX.posixSecondsToUTCTime 0
-                       , buildResultCpuUser = Nothing
-                       , buildResultCpuSystem = Nothing
-                       }
-              )
-      prop "> 1.28"
-        $ \sd -> forAll (arbitrary `suchThat` ((> 28) . protoVersion_minor))
-        $ \pv ->
-            roundtripS (buildResult sd pv)
-            . (\x -> x { buildResultStatus = case buildResultStatus x of
-                          Right (BuildSuccess st _bo) -> Right (BuildSuccess st mempty)
-                          Left f -> Left f
-                       })
-            . (\x -> x { buildResultCpuUser = Nothing
-                       , buildResultCpuSystem = Nothing
-                       }
-              )
+    prop "BuildResult"
+      $ \sd pv ->
+          let pv' = pv { protoVersion_features = Data.Set.singleton featureRealisationWithPath }
+          in roundtripS (buildResult sd pv')
+          . (\x -> x { buildResultStatus = case buildResultStatus x of
+                        Right (BuildSuccess st _bo) -> Right (BuildSuccess st mempty)
+                        Left f -> Left f
+                     })
+          . (\x -> x { buildResultCpuUser = Nothing
+                     , buildResultCpuSystem = Nothing
+                     }
+            )
 
     prop "StorePath" $ \sd ->
       roundtripS (storePath sd)
@@ -130,15 +99,12 @@ spec = parallel $ do
       prop "ActivityResult" $ roundtripS activityResult
       prop "Field" $ roundtripS field
       prop "Trace" $ roundtripS trace
-      prop "BasicError" $ roundtripS basicError
       prop "ErrorInfo" $ roundtripS errorInfo
       prop "LoggerOpCode" $ roundtripS loggerOpCode
       prop "Verbosity" $ roundtripS verbosity
       prop "Logger"
         $ forAll (arbitrary :: Gen ProtoVersion)
-        $ \pv ->
-            forAll (arbitrary `suchThat` errorInfoIf (protoVersion_minor pv >= 26))
-        $ roundtripS (logger pv)
+        $ \pv -> roundtripS (logger pv)
 
   describe "Handshake" $ do
     prop "WorkerMagic" $ roundtripS workerMagic
@@ -161,12 +127,5 @@ spec = parallel $ do
     prop "Maybe (Metadata StorePath)" $ \sd -> roundtripS (maybePathMetadata sd)
 
 restrictProtoVersion :: ProtoVersion -> Some StoreRequest -> Bool
-restrictProtoVersion v (Some (BuildPaths _ _)) | v < ProtoVersion 1 30 = False
-restrictProtoVersion v (Some (QueryMissing _)) | v < ProtoVersion 1 30 = False
 restrictProtoVersion _ _ = True
 
-errorInfoIf :: Bool -> Logger -> Bool
-errorInfoIf True  (Logger_Error (Right _)) = True
-errorInfoIf False (Logger_Error (Left _))  = True
-errorInfoIf _     (Logger_Error _)         = False
-errorInfoIf _     _                        = True

--- a/hnix-store-remote/tests/NixSerializerSpec.hs
+++ b/hnix-store-remote/tests/NixSerializerSpec.hs
@@ -16,7 +16,7 @@ import System.Nix.Derivation.Traditional qualified
 import System.Nix.Store.Remote.Arbitrary ()
 import System.Nix.Store.Remote.Serializer
 import System.Nix.Store.Remote.Types.Logger ()
-import System.Nix.Store.Remote.Types.ProtoVersion (ProtoVersion(..), featureRealisationWithPath)
+import System.Nix.Store.Remote.Types.ProtoVersion (ProtoVersion(..), ProtoFeature(..))
 import System.Nix.Store.Remote.Types.StoreRequest (StoreRequest(..))
 
 -- | Test for roundtrip using @NixSerializer@
@@ -55,7 +55,7 @@ spec = parallel $ do
 
     prop "BuildResult"
       $ \sd pv ->
-          let pv' = pv { protoVersion_features = Data.Set.singleton featureRealisationWithPath }
+          let pv' = pv { protoVersion_features = Data.Set.singleton ProtoFeature_RealisationWithPathNotHash }
           in roundtripS (buildResult sd pv')
           . (\x -> x { buildResultStatus = case buildResultStatus x of
                         Right (BuildSuccess st _bo) -> Right (BuildSuccess st mempty)
@@ -92,6 +92,9 @@ spec = parallel $ do
         System.Nix.Derivation.Traditional.withoutName drv
 
     prop "ProtoVersion" $ roundtripS @() @ProtoVersion protoVersion
+
+    prop "ProtoFeature" $ roundtripS protoFeature
+    prop "Set ProtoFeature" $ roundtripS protoFeatures
 
     describe "Logger" $ do
       prop "ActivityID" $ roundtripS activityID


### PR DESCRIPTION
Like Harmonia, require protocol >= 1.37 and the
`realisation-with-path-not-hash` feature. This simplifies the serializers by removing version branches for old protocols.

- `AddToStore`: new wire format (>= 1.25) with `ContentAddressMethod` + `HashAlgo` + refs + repair, framed NAR source, `ValidPathInfo` reply
- `ProtoVersion`: add `Set Text` features field, feature negotiation in handshake (>= 1.38), `PartialOrd` instance
- Remove `BasicError` — always use `ErrorInfo` (>= 1.26)
- Remove `BuildTraceKey`-based `builtOutputs` — require `realisation-with-path-not-hash` feature for `OutputName`-keyed format
- Remove `derivedPath` protocol version parameter (>= 1.30 unconditional)
- Remove old `buildResult` version branches (>= 1.28, >= 1.29)
- Server: implement `readFramedSource` for `AddToStore` NAR data, send `ValidPathInfo` reply matching daemon wire format
- Client: implement `writeFramedNarSource`, `validPathInfo` serializer
- Add `methodAlgoBuilder`/`methodAlgoParser` to `ContentAddress`