### PR TITLE
hnix-store-json: Include version in Derivation

### DIFF
--- a/hnix-store-json/src/System/Nix/JSON.hs
+++ b/hnix-store-json/src/System/Nix/JSON.hs
@@ -224,7 +224,8 @@ instance FromJSON Derivation where
 
 instance ToJSON Derivation where
   toJSON (Derivation name outputs (DerivationInputs inputSrcs inputDrvs) system builder args env) =
-    object [ "name" .= name
+    object [ "version" .= (4 :: Int)
+           , "name" .= name
            , "outputs" .= derivationOutputsToJSON outputs
            , "inputs" .= object
               [ "srcs" .= inputSrcs


### PR DESCRIPTION
The `nix derivation add` command now requires a version in the imported json and `nix derivation show` includes a version, both version 4.