### PR TITLE
remote: implement the builder-rpc-v0 interface

### DIFF
--- a/hnix-store-remote/CHANGELOG.md
+++ b/hnix-store-remote/CHANGELOG.md
@@ -13,6 +13,11 @@
    * Feature negotiation during handshake (client and server) when both sides >= 1.38
    * `PartialOrd` replaces `Ord` on `ProtoVersion` (from `lattices`)
    * New dependency: `lattices`
+   * Support for the `builder-rpc-v0` interface
+     * New `SubmitOutput` (1000) and `AddToStoreScanning` (1001) operations, with `submitOutput` and `addToStoreScanning` client functions
+     * `builderRpcV0` constant for the pinned profile, set it as the client's `ProtoVersion` before the handshake
+     * `WorkerOp` wire mapping now goes through `workerOpToWord64` and `word64ToWorkerOp` since opcodes are no longer contiguous
+     * New `singleDerivedPath` serializer
 
 # [0.7.0.0](https://github.com/haskell-nix/hnix-store/compare/remote-0.6.0.0...remote-0.7.0.0) 2024-07-31
 

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Arbitrary.hs
@@ -100,6 +100,7 @@ deriving via GenericArbitrary WorkerOp
 instance Arbitrary (Some StoreRequest) where
   arbitrary = oneof
     [ Some <$> (AddToStore <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary)
+    , Some <$> (AddToStoreScanning <$> arbitrary <*> arbitrary <*> arbitrary)
     , Some <$> (AddTextToStore <$> arbitrary <*> arbitrary <*> pure RepairMode_DontRepair)
     , Some <$> (AddSignatures <$> arbitrary <*> arbitrary)
     , Some . AddIndirectRoot  <$> arbitrary
@@ -128,6 +129,7 @@ instance Arbitrary (Some StoreRequest) where
     , Some . QueryPathFromHashPart <$> arbitrary
     , Some . QueryMissing <$> arbitrary
     , pure $ Some OptimiseStore
+    , Some <$> (SubmitOutput <$> arbitrary <*> arbitrary)
     , pure $ Some SyncWithGC
     , Some <$> (VerifyStore <$> arbitrary <*> arbitrary)
     ]

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Client.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Client.hs
@@ -1,6 +1,7 @@
 module System.Nix.Store.Remote.Client
   ( addToStore
   , addToStoreNar
+  , addToStoreScanning
   , addTextToStore
   , addSignatures
   , addTempRoot
@@ -23,6 +24,7 @@ module System.Nix.Store.Remote.Client
   , queryPathFromHashPart
   , queryMissing
   , optimiseStore
+  , submitOutput
   , syncWithGC
   , verifyStore
   , module System.Nix.Store.Remote.Client.Core
@@ -40,15 +42,17 @@ import Data.Word (Word64)
 import System.Nix.Build (BuildMode, BuildResult)
 import System.Nix.Derivation.Traditional qualified
 import System.Nix.Derivation.ATerm qualified
-import System.Nix.DerivedPath (DerivedPath)
+import System.Nix.DerivedPath (DerivedPath, SingleDerivedPath)
 import System.Nix.Hash (HashAlgo(..))
 import System.Nix.Nar (NarSource)
+import System.Nix.OutputName (OutputName)
 import System.Nix.Signature (Signature)
 import System.Nix.StorePath (StorePath, StorePathHashPart, StorePathName)
 import System.Nix.StorePath.Metadata (Metadata)
 import System.Nix.Store.Remote.MonadStore
 import System.Nix.Store.Remote.Types.GC (GCOptions, GCResult, GCRoot)
 import System.Nix.Store.Remote.Types.CheckMode (CheckMode)
+import System.Nix.Store.Remote.Types.ProtoVersion (ProtoFeature(..), hasFeature)
 import System.Nix.Store.Remote.Types.Query.Missing (Missing)
 import System.Nix.Store.Remote.Types.StoreRequest (StoreRequest(..))
 import System.Nix.Store.Remote.Types.StoreText (StoreText)
@@ -77,6 +81,24 @@ addToStore
 addToStore name source method hashAlgo refs repair = do
   setNarSource source
   doReq (AddToStore name method hashAlgo refs repair)
+
+-- | Add `NarSource` to the store, letting the daemon scan the
+-- contents for references instead of declaring them.
+--
+-- Only valid on connections where @add-to-store-scanning@ was
+-- negotiated, i.e. inside a derivation build with the
+-- @recursive-nix@ or @builder-rpc-v0@ system feature.
+addToStoreScanning
+  :: MonadRemoteStore m
+  => StorePathName        -- ^ Name part of the newly created `StorePath`
+  -> NarSource IO         -- ^ Provide nar stream
+  -> ContentAddressMethod -- ^ Content addressing method
+  -> Some HashAlgo        -- ^ Hashing algorithm
+  -> m StorePath
+addToStoreScanning name source method hashAlgo = do
+  requireProtoFeature ProtoFeature_AddToStoreScanning
+  setNarSource source
+  doReq (AddToStoreScanning name method hashAlgo)
 
 addToStoreNar
   :: MonadRemoteStore m
@@ -282,10 +304,37 @@ optimiseStore
   => m ()
 optimiseStore = (void . doReq) OptimiseStore
 
+-- | Register a store object as an output of the currently running
+-- derivation.
+--
+-- Only valid on connections where @submit-output@ was negotiated,
+-- i.e. inside a derivation build with the @builder-rpc-v0@ system
+-- feature.
+submitOutput
+  :: MonadRemoteStore m
+  => SingleDerivedPath
+  -> OutputName
+  -> m ()
+submitOutput path output = do
+  requireProtoFeature ProtoFeature_SubmitOutput
+  void $ doReq (SubmitOutput path output)
+
 syncWithGC
   :: MonadRemoteStore m
   => m ()
 syncWithGC = (void . doReq) SyncWithGC
+
+-- | Fail early with a clear error instead of letting the daemon
+-- reject the opcode.
+requireProtoFeature
+  :: MonadRemoteStore m
+  => ProtoFeature
+  -> m ()
+requireProtoFeature f = do
+  pv <- getProtoVersion
+  Control.Monad.when
+    (not $ hasFeature f pv)
+    $ throwError $ RemoteStoreError_ProtocolFeatureNotNegotiated f
 
 verifyStore
   :: MonadRemoteStore m

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Client/Core.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Client/Core.hs
@@ -86,6 +86,21 @@ doReq = \case
           $ validPathInfo storeDir
         pure path
 
+      AddToStoreScanning {} -> do
+        ms <- takeNarSource
+        soc <- getStoreSocket
+        case ms of
+          Just (stream :: NarSource IO) ->
+            liftIO $ writeFramedNarSource stream soc
+          Nothing ->
+            throwError
+              RemoteStoreError_NoNarSourceProvided
+        processOutput
+        (path, _metadata) <- sockGetS
+          $ mapErrorS RemoteStoreError_SerializerGet
+          $ validPathInfo storeDir
+        pure path
+
       AddToStoreNar _ meta _ _ -> do
         let narBytes = maybe 0 id $ metadataNarBytes meta
         maybeDataSource <- takeDataSource

--- a/hnix-store-remote/src/System/Nix/Store/Remote/MonadStore.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/MonadStore.hs
@@ -30,7 +30,7 @@ import System.Nix.Nar (NarSource)
 import System.Nix.StorePath (HasStoreDir(..), StoreDir)
 import System.Nix.Store.Remote.Serializer (HandshakeSError, LoggerSError, RequestSError, ReplySError, SError)
 import System.Nix.Store.Remote.Types.Logger (Logger, ErrorInfo)
-import System.Nix.Store.Remote.Types.ProtoVersion (HasProtoVersion(..), ProtoVersion)
+import System.Nix.Store.Remote.Types.ProtoVersion (HasProtoVersion(..), ProtoFeature, ProtoVersion)
 import System.Nix.Store.Remote.Types.StoreConfig (ProtoStoreConfig(..))
 
 import Data.DList qualified
@@ -85,6 +85,7 @@ data RemoteStoreError
   | RemoteStoreError_NoDataSinkSizeProvided -- remoteStoreStateMDataSinkSize is required but it is Nothing
   | RemoteStoreError_NoNarSourceProvided
   | RemoteStoreError_OperationFailed
+  | RemoteStoreError_ProtocolFeatureNotNegotiated ProtoFeature
   | RemoteStoreError_ProtocolMismatch
   | RemoteStoreError_RapairNotSupportedByRemoteStore -- "repairing is not supported when building through the Nix daemon"
   | RemoteStoreError_WorkerMagic2Mismatch

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Serializer.hs
@@ -60,6 +60,7 @@ module System.Nix.Store.Remote.Serializer
   , basicDerivation
   -- * Derivation
   , derivedPath
+  , singleDerivedPath
   -- * Build
   , buildMode
   -- * Logger
@@ -152,7 +153,7 @@ import System.Nix.ContentAddress (ContentAddress, methodAlgoBuilder, methodAlgoP
 import System.Nix.ContentAddress qualified
 import System.Nix.Derivation.Traditional
 import System.Nix.Derivation
-import System.Nix.DerivedPath (DerivedPath(..), ParseOutputsError)
+import System.Nix.DerivedPath (DerivedPath(..), SingleDerivedPath(..), ParseOutputsError)
 import System.Nix.DerivedPath qualified
 import System.Nix.Hash (HashAlgo(..))
 import System.Nix.Hash qualified
@@ -203,7 +204,9 @@ data SError
   | SError_Name InvalidNameError
   | SError_Path InvalidPathError
   | SError_Signature String
+  | SError_SingleDerivedPathInvalidTag Word64
   | SError_UnknownProtoFeature Text
+  | SError_InvalidWorkerOp Word64
   deriving (Eq, Generic, Show)
 
 
@@ -777,6 +780,30 @@ derivedPath storeDir = Serializer
   , putS = putS (derivedPathNew storeDir)
   }
 
+-- | Tagged, recursive format used by the builder-rpc-v0 operations,
+-- unlike 'derivedPath' which round-trips through the textual
+-- rendering.
+singleDerivedPath
+  :: StoreDir
+  -> NixSerializer SError SingleDerivedPath
+singleDerivedPath storeDir = Serializer
+  { getS = getS (int @Word64) >>= \case
+      0 -> SingleDerivedPath_Opaque <$> getS (storePath storeDir)
+      1 -> do
+        drvPath <- getS (singleDerivedPath storeDir)
+        output <- getS outputName
+        pure $ SingleDerivedPath_Built drvPath output
+      x -> throwError $ SError_SingleDerivedPathInvalidTag x
+  , putS = \case
+      SingleDerivedPath_Opaque p -> do
+        putS (int @Word64) 0
+        putS (storePath storeDir) p
+      SingleDerivedPath_Built drvPath output -> do
+        putS (int @Word64) 1
+        putS (singleDerivedPath storeDir) drvPath
+        putS outputName output
+  }
+
 -- * Build
 
 buildMode :: NixSerializer SError BuildMode
@@ -1013,7 +1040,14 @@ storeText = Serializer
   }
 
 workerOp :: NixSerializer SError WorkerOp
-workerOp = enum
+workerOp = Serializer
+  { getS = getS int >>=
+      either
+        (throwError . SError_InvalidWorkerOp)
+        pure
+      . word64ToWorkerOp
+  , putS = putS int . workerOpToWord64
+  }
 
 -- * Request
 
@@ -1040,6 +1074,14 @@ storeRequest storeDir _pv = Serializer
         repairBool <- getS bool
         let repair = if repairBool then RepairMode_DoRepair else RepairMode_DontRepair
         pure $ Some (AddToStore pathName method hashAlgo refs repair)
+
+      WorkerOp_AddToStoreScanning -> mapGetE $ do
+        pathName <- getS storePathName
+        camStr <- getS text
+        (method, hashAlgo) <- case Data.Attoparsec.Text.parseOnly methodAlgoParser camStr of
+          Left e -> fail e
+          Right x -> pure x
+        pure $ Some (AddToStoreScanning pathName method hashAlgo)
 
       WorkerOp_AddToStoreNar -> mapGetE $ do
         storePath' <- getS $ storePath storeDir
@@ -1140,6 +1182,11 @@ storeRequest storeDir _pv = Serializer
       WorkerOp_OptimiseStore -> mapGetE $ do
         pure $ Some OptimiseStore
 
+      WorkerOp_SubmitOutput -> mapGetE $ do
+        path <- getS $ singleDerivedPath storeDir
+        output <- getS outputName
+        pure $ Some (SubmitOutput path output)
+
       WorkerOp_SyncWithGC -> mapGetE $ do
         pure $ Some SyncWithGC
 
@@ -1183,6 +1230,15 @@ storeRequest storeDir _pv = Serializer
           $ methodAlgoBuilder method hashAlgo
         putS (set (storePath storeDir)) refs
         putS bool (repair == RepairMode_DoRepair)
+
+      Some (AddToStoreScanning pathName method hashAlgo) -> do
+        putS workerOp WorkerOp_AddToStoreScanning
+
+        putS storePathName pathName
+        putS text
+          $ Data.Text.Lazy.toStrict
+          $ Data.Text.Lazy.Builder.toLazyText
+          $ methodAlgoBuilder method hashAlgo
 
       Some (AddToStoreNar storePath' metadata repair checkSigs) -> do
         putS workerOp WorkerOp_AddToStoreNar
@@ -1296,6 +1352,12 @@ storeRequest storeDir _pv = Serializer
 
       Some OptimiseStore -> do
         putS workerOp WorkerOp_OptimiseStore
+
+      Some (SubmitOutput path output) -> do
+        putS workerOp WorkerOp_SubmitOutput
+
+        putS (singleDerivedPath storeDir) path
+        putS outputName output
 
       Some SyncWithGC -> do
         putS workerOp WorkerOp_SyncWithGC

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Server.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Server.hs
@@ -130,6 +130,10 @@ processConnection workerHelper postGreet sock = do
               let proxyNarSource :: NarSource IO
                   proxyNarSource sink = readFramedSource sock sink
               pure $ setNarSource proxyNarSource
+            AddToStoreScanning {} -> do
+              let proxyNarSource :: NarSource IO
+                  proxyNarSource sink = readFramedSource sock sink
+              pure $ setNarSource proxyNarSource
             _ -> pure $ pure ()
 
           res <-
@@ -159,6 +163,17 @@ processConnection workerHelper postGreet sock = do
                         (reply, meta)
                     Right Nothing ->
                       throwError $ RemoteStoreError_Fixme "AddToStore: path not found after adding"
+                AddToStoreScanning {} -> do
+                  metadata <- lift $ workerHelper $ doReq (QueryPathInfo reply)
+                  case fst metadata of
+                    Left e -> throwError e
+                    Right (Just meta) ->
+                      sockPutS
+                        (mapErrorS RemoteStoreError_SerializerPut
+                          $ validPathInfo storeDir)
+                        (reply, meta)
+                    Right Nothing ->
+                      throwError $ RemoteStoreError_Fixme "AddToStoreScanning: path not found after adding"
                 _ ->
                   sockPutS
                     (mapErrorS
@@ -183,6 +198,7 @@ processConnection workerHelper postGreet sock = do
           () <- Data.Some.withSome someReq $ \case
             r@AddToStore {} -> perform r
             r@AddToStoreNar {} -> perform r
+            r@AddToStoreScanning {} -> perform r
             r@AddTextToStore {} -> perform r
             r@AddSignatures {} -> perform r
             r@AddTempRoot {} -> perform r
@@ -205,6 +221,7 @@ processConnection workerHelper postGreet sock = do
             r@QueryPathFromHashPart {} -> perform r
             r@QueryMissing {} -> perform r
             r@OptimiseStore {} -> perform r
+            r@SubmitOutput {} -> perform r
             r@SyncWithGC {} -> perform r
             r@VerifyStore {} -> perform r
           loop

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/ProtoVersion.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/ProtoVersion.hs
@@ -7,6 +7,7 @@ module System.Nix.Store.Remote.Types.ProtoVersion
   , HasProtoVersion(..)
   , hasFeature
   , minVersionNumber
+  , builderRpcV0
   ) where
 
 import Algebra.PartialOrd (PartialOrd(..))
@@ -19,14 +20,26 @@ import GHC.Generics (Generic)
 
 -- | An optional protocol capability, negotiated during handshake.
 data ProtoFeature
-  = ProtoFeature_RealisationWithPathNotHash
+  = ProtoFeature_AddToStoreScanning
+  -- ^ The AddToStoreScanning operation, only offered by the daemon
+  -- inside derivation builds with the @recursive-nix@ or
+  -- @builder-rpc-v0@ system feature.
+  | ProtoFeature_DisableSetOptions
+  -- ^ The client promises not to send SetOptions after handshake.
+  | ProtoFeature_RealisationWithPathNotHash
   -- ^ Use StorePath-based realisations instead of hash-based ones.
+  | ProtoFeature_SubmitOutput
+  -- ^ The SubmitOutput operation, only offered by the daemon inside
+  -- derivation builds with the @builder-rpc-v0@ system feature.
   deriving (Bounded, Enum, Eq, Generic, Ord, Show)
 
 -- | The name of a feature as exchanged on the wire.
 protoFeatureToText :: ProtoFeature -> Text
 protoFeatureToText = \case
+  ProtoFeature_AddToStoreScanning -> "add-to-store-scanning"
+  ProtoFeature_DisableSetOptions -> "disable-set-options"
   ProtoFeature_RealisationWithPathNotHash -> "realisation-with-path-not-hash"
+  ProtoFeature_SubmitOutput -> "submit-output"
 
 protoFeatureFromText :: Text -> Maybe ProtoFeature
 protoFeatureFromText t =
@@ -65,6 +78,23 @@ instance Default ProtoVersion where
     , protoVersion_minor = 38
     , protoVersion_features = Data.Set.singleton ProtoFeature_RealisationWithPathNotHash
     }
+
+-- | The protocol profile spoken on the daemon socket exposed to
+-- builders of derivations with the @builder-rpc-v0@ system feature
+-- (NixOS/nix#15793).
+--
+-- Frozen upstream, since any change would be derivation-visible.
+builderRpcV0 :: ProtoVersion
+builderRpcV0 = ProtoVersion
+  { protoVersion_major = 1
+  , protoVersion_minor = 38
+  , protoVersion_features = Data.Set.fromList
+      [ ProtoFeature_RealisationWithPathNotHash
+      , ProtoFeature_DisableSetOptions
+      , ProtoFeature_AddToStoreScanning
+      , ProtoFeature_SubmitOutput
+      ]
+  }
 
 class HasProtoVersion r where
   hasProtoVersion :: r -> ProtoVersion

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/ProtoVersion.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/ProtoVersion.hs
@@ -80,8 +80,7 @@ instance Default ProtoVersion where
     }
 
 -- | The protocol profile spoken on the daemon socket exposed to
--- builders of derivations with the @builder-rpc-v0@ system feature
--- (NixOS/nix#15793).
+-- builders of derivations with the @builder-rpc-v0@ system feature.
 --
 -- Frozen upstream, since any change would be derivation-visible.
 builderRpcV0 :: ProtoVersion

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/StoreRequest.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/StoreRequest.hs
@@ -16,9 +16,10 @@ import Data.Some (Some(Some))
 
 import System.Nix.Build (BuildMode, BuildResult)
 import System.Nix.Derivation (BasicDerivation)
-import System.Nix.DerivedPath (DerivedPath)
+import System.Nix.DerivedPath (DerivedPath, SingleDerivedPath)
 import System.Nix.ContentAddress (ContentAddressMethod)
 import System.Nix.Hash (HashAlgo)
+import System.Nix.OutputName (OutputName)
 import System.Nix.Signature (Signature)
 import System.Nix.Store.Types (RepairMode)
 import System.Nix.StorePath (StorePath, StorePathName, StorePathHashPart)
@@ -48,6 +49,18 @@ data StoreRequest :: Type -> Type where
     -> RepairMode
     -> CheckMode -- ^ Whether to check signatures
     -> StoreRequest NoReply
+
+  -- | Add @NarSource@ to the store, letting the daemon scan the
+  -- contents for references instead of declaring them.
+  --
+  -- Only available inside a derivation build with the
+  -- @recursive-nix@ or @builder-rpc-v0@ system feature, when the
+  -- @add-to-store-scanning@ protocol feature was negotiated.
+  AddToStoreScanning
+    :: StorePathName -- ^ Name part of the newly created @StorePath@
+    -> ContentAddressMethod -- ^ Content addressing method
+    -> Some HashAlgo -- ^ Hashing algorithm
+    -> StoreRequest StorePath
 
   -- | Add text to store.
   --
@@ -156,6 +169,17 @@ data StoreRequest :: Type -> Type where
   OptimiseStore
     :: StoreRequest SuccessCodeReply
 
+  -- | Register a store object as an output of the currently running
+  -- derivation.
+  --
+  -- Only available inside a derivation build with the
+  -- @builder-rpc-v0@ system feature, when the @submit-output@
+  -- protocol feature was negotiated.
+  SubmitOutput
+    :: SingleDerivedPath
+    -> OutputName
+    -> StoreRequest SuccessCodeReply
+
   SyncWithGC
     :: StoreRequest SuccessCodeReply
 
@@ -175,6 +199,7 @@ deriveGShow ''StoreRequest
 instance {-# OVERLAPPING #-} Eq (Some StoreRequest) where
   Some (AddToStore a b c d e) == Some (AddToStore a' b' c' d' e') = (a, b, c, d, e) == (a', b', c', d', e')
   Some (AddToStoreNar a b c d) == Some (AddToStoreNar a' b' c' d') = (a, b, c, d) == (a', b', c', d')
+  Some (AddToStoreScanning a b c) == Some (AddToStoreScanning a' b' c') = (a, b, c) == (a', b', c')
   Some (AddTextToStore a b c) == Some (AddTextToStore a' b' c') = (a, b, c) == (a', b', c')
   Some (AddSignatures a b) == Some (AddSignatures a' b') = (a, b) == (a', b')
   Some (AddIndirectRoot a) == Some (AddIndirectRoot a') = a == a'
@@ -197,6 +222,7 @@ instance {-# OVERLAPPING #-} Eq (Some StoreRequest) where
   Some (QueryPathFromHashPart a) == Some (QueryPathFromHashPart a') = a == a'
   Some (QueryMissing a) == Some (QueryMissing a') = a == a'
   Some OptimiseStore == Some OptimiseStore = True
+  Some (SubmitOutput a b) == Some (SubmitOutput a' b') = (a, b) == (a', b')
   Some SyncWithGC == Some SyncWithGC = True
   Some (VerifyStore a b) == Some (VerifyStore a' b') = (a, b) == (a', b')
 

--- a/hnix-store-remote/src/System/Nix/Store/Remote/Types/WorkerOp.hs
+++ b/hnix-store-remote/src/System/Nix/Store/Remote/Types/WorkerOp.hs
@@ -1,13 +1,19 @@
 module System.Nix.Store.Remote.Types.WorkerOp
   ( WorkerOp(..)
+  , workerOpToWord64
+  , word64ToWorkerOp
   ) where
 
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 
 -- | Worker opcode
 --
 -- This type has gaps filled in so that the GHC builtin
--- Enum instance lands on the right values.
+-- Enum instance lands on the right values for the contiguous
+-- 0-46 range. The builder-rpc-v0 opcodes at 1000+ don't follow
+-- the Enum values, so the wire mapping goes through
+-- 'workerOpToWord64' and 'word64ToWorkerOp'.
 data WorkerOp
   = WorkerOp_Reserved_0__ -- 0
   | WorkerOp_IsValidPath -- 1
@@ -56,4 +62,20 @@ data WorkerOp
   | WorkerOp_AddMultipleToStore --  44 0x2c
   | WorkerOp_AddBuildLog --  45 0x2d
   | WorkerOp_BuildPathsWithResults --  46 0x2e
+  | WorkerOp_SubmitOutput -- 1000, builder-rpc-v0 only
+  | WorkerOp_AddToStoreScanning -- 1001, recursive-nix or builder-rpc-v0 only
   deriving (Bounded, Eq, Enum, Generic, Ord, Show, Read)
+
+workerOpToWord64 :: WorkerOp -> Word64
+workerOpToWord64 = \case
+  WorkerOp_SubmitOutput -> 1000
+  WorkerOp_AddToStoreScanning -> 1001
+  op -> fromIntegral (fromEnum op)
+
+word64ToWorkerOp :: Word64 -> Either Word64 WorkerOp
+word64ToWorkerOp = \case
+  1000 -> Right WorkerOp_SubmitOutput
+  1001 -> Right WorkerOp_AddToStoreScanning
+  x | x <= fromIntegral (fromEnum WorkerOp_BuildPathsWithResults) ->
+        Right $ toEnum $ fromIntegral x
+    | otherwise -> Left x

--- a/hnix-store-remote/tests/EnumSpec.hs
+++ b/hnix-store-remote/tests/EnumSpec.hs
@@ -13,6 +13,7 @@ import System.Nix.Store.Remote.Serializer
   , int
   , loggerOpCode
   , runP
+  , workerOp
   , LoggerSError
   , NixSerializer
   , SError
@@ -132,8 +133,15 @@ spec = do
         itE "Vomit"     Verbosity_Vomit     7
 
       describe "WorkerOp enum order matches Nix" $ do
-        itE "IsValidPath"           WorkerOp_IsValidPath            1
-        itE "BuildPathsWithResults" WorkerOp_BuildPathsWithResults 46
+        let itW name constr value =
+              it name
+                $ runP workerOp constr
+                  `shouldBe`
+                  runP @SError (int @Word64) value
+        itW "IsValidPath"           WorkerOp_IsValidPath              1
+        itW "BuildPathsWithResults" WorkerOp_BuildPathsWithResults   46
+        itW "SubmitOutput"          WorkerOp_SubmitOutput          1000
+        itW "AddToStoreScanning"    WorkerOp_AddToStoreScanning    1001
 
 
 

--- a/hnix-store-remote/tests/NixSerializerSpec.hs
+++ b/hnix-store-remote/tests/NixSerializerSpec.hs
@@ -91,6 +91,9 @@ spec = parallel $ do
       roundtripS (basicDerivation sd) $
         System.Nix.Derivation.Traditional.withoutName drv
 
+    prop "SingleDerivedPath" $ \sd ->
+      roundtripS (singleDerivedPath sd)
+
     prop "ProtoVersion" $ roundtripS @() @ProtoVersion protoVersion
 
     prop "ProtoFeature" $ roundtripS protoFeature


### PR DESCRIPTION
> [!NOTE]
> Depends on #314

This PR adds client support for the new builder RPC. Builders inside a
derivation with the `builder-rpc-v0` system feature get a restricted
daemon socket, and can create store objects mid-build with references
scanned by the daemon, then register them as outputs of the running
derivation. This adds:

- A new `SubmitOutput` (1000) and `AddToStoreScanning` (1001) operation, with `submitOutput` and `addToStoreScanning` client functions
- A `builderRpcV0` constant for the pinned protocol profile, set to the client's `ProtoVersion` before the handshake
- The `WorkerOp` wire mapping now goes through `workerOpToWord64` and `word64ToWorkerOp` since opcodes are no longer contiguous
- New `singleDerivedPath` serializer for the tagged recursive format

