### PR TITLE
README: drop dependencies badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ several Haskell packages.
 ### [hnix-store-core]
 
 [![Hackage version](https://img.shields.io/hackage/v/hnix-store-core.svg?color=success)](https://hackage.haskell.org/package/hnix-store-core)
-[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-core?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-core)
 
 Contains the core types and
 fundamental operations, agnostic to any particular
@@ -62,35 +61,30 @@ bring in a specific implementation.
 ### [hnix-store-db]
 
 [![Hackage version](https://img.shields.io/hackage/v/hnix-store-db.svg?color=success)](https://hackage.haskell.org/package/hnix-store-db)
-[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-db?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-db)
 
 Implementation of the `Nix` store SQLite database.
 
 ### [hnix-store-json]
 
 [![Hackage version](https://img.shields.io/hackage/v/hnix-store-json.svg?color=success)](https://hackage.haskell.org/package/hnix-store-json)
-[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-json?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-json)
 
 `Aeson` instances for core types, required for remote store protocol.
 
 ### [hnix-store-nar]
 
 [![Hackage version](https://img.shields.io/hackage/v/hnix-store-nar.svg?color=success)](https://hackage.haskell.org/package/hnix-store-nar)
-[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-nar?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-nar)
 
 Packing and unpacking for NAR file format used by Nix.
 
 ### [hnix-store-readonly]
 
 [![Hackage version](https://img.shields.io/hackage/v/hnix-store-readonly.svg?color=success)](https://hackage.haskell.org/package/hnix-store-readonly)
-[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-readonly?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-readonly)
 
 Path computation without interaction with the actual `Nix` store
 
 ### [hnix-store-remote]
 
 [![Hackage version](https://img.shields.io/hackage/v/hnix-store-remote.svg?color=success)](https://hackage.haskell.org/package/hnix-store-remote)
-[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-remote?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-remote)
 
 [Nix] worker protocol implementation for interacting with remote Nix store
 via `nix-daemon`.
@@ -98,7 +92,6 @@ via `nix-daemon`.
 ### [hnix-store-tests]
 
 [![Hackage version](https://img.shields.io/hackage/v/hnix-store-tests.svg?color=success)](https://hackage.haskell.org/package/hnix-store-tests)
-[![Dependencies](https://img.shields.io/hackage-deps/v/hnix-store-tests?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix-store-tests)
 
 Aribtrary instances and utilities for testing.
 


### PR DESCRIPTION
Tried to fix via https://github.com/badges/shields/pull/11511 but decided I don't care.